### PR TITLE
Handle linux based rippers that use Windows Plex servers

### DIFF
--- a/src/Domain/Entities/Download/DownloadTask.cs
+++ b/src/Domain/Entities/Download/DownloadTask.cs
@@ -141,7 +141,26 @@ namespace PlexRipper.Domain
         public string TitleTvShowEpisode => MetaData?.TvShowEpisodeTitle ?? string.Empty;
 
         [NotMapped]
-        public string FileName => Path.GetFileName(MetaData?.MediaData?.First()?.Parts?.First()?.File ?? string.Empty);
+        public string FileName {
+            get {
+                var originalFile = MetaData?.MediaData?.First()?.Parts?.First()?.File ?? string.Empty;
+                if (string.IsNullOrWhiteSpace(originalFile)) {
+                    return string.Empty;
+                }
+
+                var fileName = Path.GetFileName(originalFile);
+                if (string.IsNullOrWhiteSpace(fileName)) {
+                    return string.Empty;
+                }
+
+                if (fileName.Equals(originalFile)) {
+                    // We could be on linux, but processing a file from a Windows host
+                    return fileName.Split("\\").Last();
+                }
+
+                return fileName;
+            }
+        }
 
         /// <summary>
         /// The relative obfuscated URL of the media to be downloaded, e.g: /library/parts/47660/156234666/file.mkv.


### PR DESCRIPTION
`Path.GetFileName` does not handle Windows paths when run on a Linux server.  This change will selet `bar.mkv` from `C:\Movies\Foo\bar.mkv`