### PR TITLE
Fixed the setup loop that happened for some users where they got redirected back to the setup screen after finishing or skipping by removing the redirect

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -3,21 +3,13 @@ name: Create PlexRipper Dev Container Release
 on:
   push:
     tags:
-      - "*"
+      - "*-dev"
 
 jobs:
   # Build Docker Image
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - name: Publish to Docker with version tag
-        uses: elgohr/Publish-Docker-Github-Action@v4
-        with:
-          name: plexripper/plexripper
-          username: "${{ secrets.DOCKER_USERNAME }}"
-          password: "${{ secrets.DOCKER_PASSWORD }}"
-          tag_names: true
       - name: Publish to Registry with dev tag
         uses: elgohr/Publish-Docker-Github-Action@v4
         with:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,35 +1,38 @@
 name: Publish Docker image on push 'master' branch
 
 on:
+  release:
+    types: [published]
   push:
     branches:
       - master
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+      - name: Publish to Docker with latest and version tag
+        pre: echo ::save-state name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
+        uses: elgohr/Publish-Docker-Github-Action@v4
         with:
           name: plexripper/plexripper
-          username: '${{ secrets.DOCKER_USERNAME }}'
-          password: '${{ secrets.DOCKER_PASSWORD }}'
-          tags: "latest"
- 
-  PushContainerReadme:
-    runs-on: ubuntu-latest
-    name: Push README to Docker Hub
-    steps:
-      - name: git checkout
-        uses: actions/checkout@v2
-      - name: push README to Dockerhub
-        uses: christian-korneck/update-container-description-action@v1
-        env:
-          DOCKER_USER: ${{ secrets.DOCKER_USERNAME }}'
-          DOCKER_PASS: '${{ secrets.DOCKER_PASSWORD }}'
-        with:
-          destination_container_repo: plexripper/plexripper
-          provider: dockerhub
-          short_description: 'my short description 😊'
-          readme_file: 'README.md'
+          username: "${{ secrets.DOCKER_USERNAME }}"
+          password: "${{ secrets.DOCKER_PASSWORD }}"
+          tags: "latest,${{ env.STATE_RELEASE_VERSION }}"
+
+  # PushContainerReadme:
+  #   runs-on: ubuntu-latest
+  #   name: Push README to Docker Hub
+  #   steps:
+  #     - name: git checkout
+  #       uses: actions/checkout@v2
+  #     - name: push README to Dockerhub
+  #       uses: christian-korneck/update-container-description-action@v1
+  #       env:
+  #         DOCKER_USER: ${{ secrets.DOCKER_USERNAME }}'
+  #         DOCKER_PASS: '${{ secrets.DOCKER_PASSWORD }}'
+  #       with:
+  #         destination_container_repo: plexripper/plexripper
+  #         provider: dockerhub
+  #         short_description: 'my short description 😊'
+  #         readme_file: 'README.md'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [0.9.1]
+
+### Added
+ - Added a setup question on the home page instead of forcefully redirecting to the setup page when the setup hasn't been yet skipped or completed
+### Changed
+ - Made the updating of settings in the front-end a true observable to make it chain-able and await-able to only do stuff after it has updated the settings
+### Fixed
+ - Fixed the setup loop that happened for some users where they got redirected back to the setup screen after finishing or skipping by removing the redirect
+ - Fixed the downloadSegments setting not updating correctly when changed
+
 ## [0.9.0]
 
 This has been a major refactoring with many unit and integration tests added to ensure stability.

--- a/src/WebAPI/ClientApp/package.json
+++ b/src/WebAPI/ClientApp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plex-ripper-web-ui",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "PlexRipper",
   "author": "JasonLandbridge",
   "private": true,

--- a/src/WebAPI/ClientApp/src/components/AppBar/AppBar.vue
+++ b/src/WebAPI/ClientApp/src/components/AppBar/AppBar.vue
@@ -85,7 +85,7 @@ export default class AppBar extends Vue {
 	}
 
 	updateActiveAccountId(accountId: number): void {
-		SettingsService.updateGeneralSettings('activeAccountId', accountId);
+		useSubscription(SettingsService.updateGeneralSettings('activeAccountId', accountId).subscribe());
 	}
 
 	refreshAccount(accountId: number = 0): void {

--- a/src/WebAPI/ClientApp/src/components/Buttons/GoToButton.vue
+++ b/src/WebAPI/ClientApp/src/components/Buttons/GoToButton.vue
@@ -23,6 +23,10 @@ export default Vue.extend({
 			type: String,
 			default: '',
 		},
+		block: {
+			type: Boolean,
+			default: false,
+		},
 	},
 	render(h: CreateElement, context: RenderContext): VNode {
 		return h(BaseButton, {

--- a/src/WebAPI/ClientApp/src/components/Buttons/NavigationSkipSetupButton.vue
+++ b/src/WebAPI/ClientApp/src/components/Buttons/NavigationSkipSetupButton.vue
@@ -14,18 +14,24 @@ export default Vue.extend({
 			type: String,
 			default: '',
 		},
+		width: {
+			type: Number,
+			default: 36,
+		},
+		block: {
+			type: Boolean,
+			default: true,
+		},
 	},
 	render(h: CreateElement, context: RenderContext): VNode {
 		return h(BaseButton, {
 			...context.data,
 			props: {
 				...context.props,
-				block: true,
 				outlined: true,
 				textId: 'skip-setup',
 				icon: 'mdi-debug-step-over',
 				iconAlign: 'Right',
-				width: 100,
 			} as Partial<IBaseButtonProps>,
 		});
 	},

--- a/src/WebAPI/ClientApp/src/components/MediaOverview/MediaOverview.vue
+++ b/src/WebAPI/ClientApp/src/components/MediaOverview/MediaOverview.vue
@@ -99,7 +99,7 @@ import Log from 'consola';
 import { Component, Prop, Ref, Vue, Watch } from 'vue-property-decorator';
 import { finalize, tap } from 'rxjs/operators';
 import { useSubscription } from '@vueuse/rxjs';
-import type { DownloadMediaDTO, PlexMediaDTO, PlexServerDTO } from '@dto/mainApi';
+import type { DisplaySettingsDTO, DownloadMediaDTO, PlexMediaDTO, PlexServerDTO } from '@dto/mainApi';
 import { DownloadTaskCreationProgress, LibraryProgress, PlexLibraryDTO, PlexMediaType, ViewMode } from '@dto/mainApi';
 import { DownloadService, LibraryService, SettingsService, SignalrService } from '@service';
 import { DetailsOverview, DownloadConfirmation, MediaTable } from '@mediaOverview';
@@ -160,13 +160,21 @@ export default class MediaOverview extends Vue {
 	}
 
 	changeView(viewMode: ViewMode): void {
+		let type: keyof DisplaySettingsDTO | null = null;
 		switch (this.mediaType) {
 			case PlexMediaType.Movie:
-				return SettingsService.updateDisplaySettings('movieViewMode', viewMode);
+				type = 'movieViewMode';
+				break;
 			case PlexMediaType.TvShow:
-				return SettingsService.updateDisplaySettings('tvShowViewMode', viewMode);
+				type = 'tvShowViewMode';
+				break;
+			default:
+				type = null;
+				Log.error('Could not set view mode for type' + this.mediaType);
 		}
-		Log.error('Could not set view mode for type' + this.mediaType);
+		if (type) {
+			useSubscription(SettingsService.updateDisplaySettings(type, viewMode).subscribe());
+		}
 	}
 
 	resetProgress(isRefreshing: boolean): void {

--- a/src/WebAPI/ClientApp/src/components/Navigation/ServerDialog/Tabs/ServerConfigTabContent.vue
+++ b/src/WebAPI/ClientApp/src/components/Navigation/ServerDialog/Tabs/ServerConfigTabContent.vue
@@ -18,8 +18,9 @@
 </template>
 
 <script lang="ts">
-import { Component, Vue, Prop } from 'vue-property-decorator';
+import { Component, Prop, Vue } from 'vue-property-decorator';
 import Log from 'consola';
+import { useSubscription } from '@vueuse/rxjs';
 import type { PlexServerDTO, PlexServerSettingsModel } from '@dto/mainApi';
 import { SettingsService } from '@service';
 
@@ -43,7 +44,9 @@ export default class ServerConfigTabContent extends Vue {
 			Log.info(value);
 			this.plexServerSettings.downloadSpeedLimit = value;
 			// Its copied due to the object containing Vue getters and setters which messes up the store
-			SettingsService.updateServerSettings(JSON.parse(JSON.stringify(this.plexServerSettings)));
+			useSubscription(
+				SettingsService.updateServerSettings(JSON.parse(JSON.stringify(this.plexServerSettings))).subscribe(),
+			);
 		}
 	}
 }

--- a/src/WebAPI/ClientApp/src/components/Views/Settings/ConfirmationSection.vue
+++ b/src/WebAPI/ClientApp/src/components/Views/Settings/ConfirmationSection.vue
@@ -53,6 +53,7 @@ import { Component, Vue } from 'vue-property-decorator';
 import Log from 'consola';
 import { useSubscription } from '@vueuse/rxjs';
 import { SettingsService } from '@service';
+import { ConfirmationSettingsDTO } from '@dto/mainApi';
 
 @Component
 export default class ConfirmationSection extends Vue {
@@ -62,17 +63,26 @@ export default class ConfirmationSection extends Vue {
 	askDownloadEpisodeConfirmation: boolean = false;
 
 	updateSettings(index: number, state: boolean): void {
+		let key: keyof ConfirmationSettingsDTO | null = null;
 		switch (index) {
 			case 0:
-				return SettingsService.updateConfirmationSetting('askDownloadMovieConfirmation', state);
+				key = 'askDownloadMovieConfirmation';
+				break;
 			case 1:
-				return SettingsService.updateConfirmationSetting('askDownloadTvShowConfirmation', state);
+				key = 'askDownloadTvShowConfirmation';
+				break;
 			case 2:
-				return SettingsService.updateConfirmationSetting('askDownloadSeasonConfirmation', state);
+				key = 'askDownloadSeasonConfirmation';
+				break;
 			case 3:
-				return SettingsService.updateConfirmationSetting('askDownloadEpisodeConfirmation', state);
+				key = 'askDownloadEpisodeConfirmation';
+				break;
 			default:
 				Log.error(`Failed to update settings with index ${index} and value ${state}`);
+				key = null;
+		}
+		if (key) {
+			useSubscription(SettingsService.updateConfirmationSetting(key, state).subscribe());
 		}
 	}
 

--- a/src/WebAPI/ClientApp/src/components/Views/Settings/DateAndTimeSection.vue
+++ b/src/WebAPI/ClientApp/src/components/Views/Settings/DateAndTimeSection.vue
@@ -81,6 +81,7 @@ import { enUS, fr } from 'date-fns/locale';
 
 import { useSubscription } from '@vueuse/rxjs';
 import { SettingsService } from '@service';
+import { DateTimeSettingsDTO } from '@dto/mainApi';
 
 interface ISelectItem {
 	text: string | number | object;
@@ -169,19 +170,29 @@ export default class DateAndTimeSection extends Vue {
 	}
 
 	updateSettings(index: number, state: any): void {
+		let key: keyof DateTimeSettingsDTO | null = null;
 		switch (index) {
 			case 0:
-				return SettingsService.updateDateTimeSetting('shortDateFormat', state);
+				key = 'shortDateFormat';
+				break;
 			case 1:
-				return SettingsService.updateDateTimeSetting('longDateFormat', state);
+				key = 'longDateFormat';
+				break;
 			case 2:
-				return SettingsService.updateDateTimeSetting('timeFormat', state);
+				key = 'timeFormat';
+				break;
 			case 3:
-				return SettingsService.updateDateTimeSetting('timeZone', state);
+				key = 'timeZone';
+				break;
 			case 4:
-				return SettingsService.updateDateTimeSetting('showRelativeDates', state);
+				key = 'showRelativeDates';
+				break;
 			default:
 				Log.error(`Failed to update settings with index ${index} and value ${state}`);
+				key = null;
+		}
+		if (key) {
+			useSubscription(SettingsService.updateDateTimeSetting(key, state).subscribe());
 		}
 	}
 

--- a/src/WebAPI/ClientApp/src/components/Views/Settings/DownloadManagerSection.vue
+++ b/src/WebAPI/ClientApp/src/components/Views/Settings/DownloadManagerSection.vue
@@ -18,29 +18,37 @@
 </template>
 
 <script lang="ts">
-import { Component, Vue } from 'vue-property-decorator';
+import { Component, Vue, Watch } from 'vue-property-decorator';
 import { useSubscription } from '@vueuse/rxjs';
-import { ref, Ref } from 'vue';
-// eslint-disable-next-line import/named
-import { watchDebounced } from '@vueuse/core';
+import { debounce, interval, Subject } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
 import { SettingsService } from '@service';
 
 @Component
 export default class DownloadManagerSection extends Vue {
-	downloadSegments: Ref<number> = ref(0);
+	downloadSegments: number = 0;
+
+	downloadSegmentSubject: Subject<number> = new Subject<number>();
+
+	@Watch('downloadSegments')
+	onDownloadSegments(newValue) {
+		this.downloadSegmentSubject.next(newValue);
+	}
 
 	mounted(): void {
-		watchDebounced(
-			this.downloadSegments,
-			(value) => {
-				SettingsService.updateDownloadManagerSetting('downloadSegments', value);
-			},
-			{ debounce: 1000, maxWait: 5000 },
+		useSubscription(
+			this.downloadSegmentSubject
+				.asObservable()
+				.pipe(
+					debounce(() => interval(1000)),
+					switchMap((value) => SettingsService.updateDownloadManagerSetting('downloadSegments', value)),
+				)
+				.subscribe(),
 		);
 
 		useSubscription(
 			SettingsService.getDownloadSegments().subscribe((downloadSegments) => {
-				this.downloadSegments.value = downloadSegments;
+				this.downloadSegments = downloadSegments;
 			}),
 		);
 	}

--- a/src/WebAPI/ClientApp/src/components/Views/Settings/LanguageSection.vue
+++ b/src/WebAPI/ClientApp/src/components/Views/Settings/LanguageSection.vue
@@ -63,8 +63,7 @@ export default class LanguageSection extends Vue {
 
 	updateSettings(langCode: string): void {
 		Log.debug('Changed language to: ', langCode);
-		this.$nuxt.$i18n.setLocale(langCode);
-		SettingsService.updateLanguageSettings('language', langCode);
+		useSubscription(SettingsService.updateLanguageSettings('language', langCode).subscribe());
 	}
 
 	mounted() {

--- a/src/WebAPI/ClientApp/src/lang/en-US.json
+++ b/src/WebAPI/ClientApp/src/lang/en-US.json
@@ -308,7 +308,8 @@
       "return-link": "Go back to home page"
     },
     "home": {
-      "header": "WORKING!"
+      "header": "WORKING!",
+      "setup-question": "It looks like this is you're first time using PlexRipper, would you like to set it up?"
     },
     "movies": {
       "index": {

--- a/src/WebAPI/ClientApp/src/pages/index.vue
+++ b/src/WebAPI/ClientApp/src/pages/index.vue
@@ -1,6 +1,19 @@
 <template>
 	<page-container>
-		<v-row>
+		<v-row v-if="firstTimeSetup">
+			<v-col cols="12">
+				<h2>{{ $t('pages.home.setup-question') }}</h2>
+				<v-row justify="center">
+					<v-col cols="3">
+						<NavigationSkipSetupButton :block="true" @click="skipSetup()" />
+					</v-col>
+					<v-col cols="3">
+						<GoToButton text-id="go-to-setup-page" :block="true" to="/setup" color="green" />
+					</v-col>
+				</v-row>
+			</v-col>
+		</v-row>
+		<v-row v-else>
 			<v-col>
 				<h1>{{ $t('pages.home.header') }}</h1>
 			</v-col>
@@ -9,8 +22,29 @@
 </template>
 
 <script lang="ts">
+import Log from 'consola';
 import { Component, Vue } from 'vue-property-decorator';
+import { useSubscription } from '@vueuse/rxjs';
+import { SettingsService } from '@service';
 
 @Component<Home>({})
-export default class Home extends Vue {}
+export default class Home extends Vue {
+	firstTimeSetup: boolean = false;
+
+	skipSetup(): void {
+		useSubscription(
+			SettingsService.updateGeneralSettings('firstTimeSetup', false).subscribe(() => {
+				Log.info('Setup process skipped');
+			}),
+		);
+	}
+
+	mounted() {
+		useSubscription(
+			SettingsService.getFirstTimeSetup().subscribe((state) => {
+				this.firstTimeSetup = state;
+			}),
+		);
+	}
+}
 </script>

--- a/src/WebAPI/ClientApp/src/pages/setup/index.vue
+++ b/src/WebAPI/ClientApp/src/pages/setup/index.vue
@@ -147,7 +147,7 @@
 		<!--	Skip button	-->
 		<v-row justify="center">
 			<v-col cols="3">
-				<NavigationSkipSetupButton :disabled="isNextDisabled" @click="skipDialogOpen = true" />
+				<NavigationSkipSetupButton :disabled="isNextDisabled" :width="100" @click="skipDialogOpen = true" />
 				<confirmation-dialog
 					text-id="skip-setup"
 					:dialog="skipDialogOpen"
@@ -161,6 +161,8 @@
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
+import { useSubscription } from '@vueuse/rxjs';
+import Log from 'consola';
 import { SettingsService } from '@service';
 
 @Component
@@ -189,11 +191,15 @@ export default class Setup extends Vue {
 	}
 
 	finishSetup(): void {
-		SettingsService.updateGeneralSettings('firstTimeSetup', false);
-		this.$router.push('/', () => {
-			// Refresh the page when we go to the home page to make sure we get all new data.
-			location.reload();
-		});
+		useSubscription(
+			SettingsService.updateGeneralSettings('firstTimeSetup', false).subscribe(() => {
+				Log.info('Setup process is finished or skipped, redirecting to home page now and refreshing the page');
+				this.$router.push('/', () => {
+					// Refresh the page when we go to the home page to make sure we get all new data.
+					location.reload();
+				});
+			}),
+		);
 	}
 
 	get headers(): string[] {

--- a/src/WebAPI/ClientApp/src/plugins/axios.ts
+++ b/src/WebAPI/ClientApp/src/plugins/axios.ts
@@ -5,6 +5,7 @@ import IAppConfig from '@class/IAppConfig';
 export default (): void => {
 	// Source: https://github.com/axios/axios/issues/41#issuecomment-484546457
 	Axios.defaults.validateStatus = () => true;
+	// Now error resolves in catch block rather than then block.
 	// Source: https://github.com/axios/axios/issues/41#issuecomment-386762576
 	Axios.interceptors.response.use(
 		(config) => {


### PR DESCRIPTION
Added a setup question on the home page instead of forcefully redirecting to the setup page when the setup hasn't been yet skipped or completed
Made the updating of settings in the front-end a true observable to make it chain-able and await-able to only do stuff after it has updated the settings
Fixed the downloadSegments setting not updating correctly when changed