### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Publish to Registry with dev tag
-        uses: elgohr/Publish-Docker-Github-Action@v4
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: plexripper/plexripper
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/master-release.yml
+++ b/.github/workflows/master-release.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Stable tag_name
         run: echo ${{ github.event.release.tag_name }}
       - name: Publish to Docker with latest and version tag
-        uses: elgohr/Publish-Docker-Github-Action@v4
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: plexripper/plexripper
           username: "${{ secrets.DOCKER_USERNAME }}"


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore