### PR TITLE
Folder/path flexibility through env vars and better default root path.

### DIFF
--- a/.run/PlexRipper Back-End Development.run.xml
+++ b/.run/PlexRipper Back-End Development.run.xml
@@ -7,9 +7,9 @@
     <envs>
       <env name="ASPNETCORE_ENVIRONMENT" value="Development" />
       <env name="ASPNETCORE_URLS" value="http://+:5000" />
-      <env name="DEVELOPMENT_ROOT_PATH" value="$PROJECT_DIR$/../../DATA/PlexRipperCache/" />
       <env name="DOTNET_ENVIRONMENT" value="Development" />
       <env name="DOTNET_URLS" value="http://+:5000" />
+      <env name="PLEXRIPPER_ROOT_PATH" value="$PROJECT_DIR$/../../DATA/PlexRipperCache/" />
     </envs>
     <option name="USE_EXTERNAL_CONSOLE" value="0" />
     <option name="USE_MONO" value="0" />

--- a/src/Data/PlexRipperDbContext.cs
+++ b/src/Data/PlexRipperDbContext.cs
@@ -16,8 +16,6 @@ namespace PlexRipper.Data;
 
 public sealed class PlexRipperDbContext : DbContext, ISetup, IPlexRipperDbContext
 {
-    private readonly IPathProvider _pathProvider;
-
     private readonly ILog<PlexRipperDbContext> _log = LogManager.CreateLogInstance<PlexRipperDbContext>();
 
     #region Properties
@@ -125,14 +123,11 @@ public sealed class PlexRipperDbContext : DbContext, ISetup, IPlexRipperDbContex
 
     #region Constructors
 
-    public PlexRipperDbContext() { }
-
-    public PlexRipperDbContext(IPathProvider pathProvider)
+    public PlexRipperDbContext()
     {
-        _pathProvider = pathProvider;
-        DatabaseName = _pathProvider.DatabaseName;
-        DatabasePath = _pathProvider.DatabasePath;
-        ConfigDirectory = _pathProvider.ConfigDirectory;
+        DatabaseName = PathProvider.DatabaseName;
+        DatabasePath = PathProvider.DatabasePath;
+        ConfigDirectory = PathProvider.ConfigDirectory;
     }
 
     public PlexRipperDbContext(DbContextOptions<PlexRipperDbContext> options, string databaseName = "") : base(options)
@@ -252,20 +247,20 @@ public sealed class PlexRipperDbContext : DbContext, ISetup, IPlexRipperDbContex
     private Result BackUpDatabase()
     {
         _log.InformationLine("Attempting to back-up the PlexRipper database");
-        if (!File.Exists(_pathProvider.DatabasePath))
-            return Result.Fail($"Could not find Database at path: {_pathProvider.DatabasePath}").LogError();
+        if (!File.Exists(PathProvider.DatabasePath))
+            return Result.Fail($"Could not find Database at path: {PathProvider.DatabasePath}").LogError();
 
         var dateString = DateTime.UtcNow.ToString("yy-MM-dd_hh-mm", CultureInfo.InvariantCulture);
-        var dbBackUpPath = Path.Combine(_pathProvider.DatabaseBackupDirectory, dateString);
+        var dbBackUpPath = Path.Combine(PathProvider.DatabaseBackupDirectory, dateString);
 
         try
         {
             Directory.CreateDirectory(dbBackUpPath);
 
             // Wait until the database is available.
-            StreamExtensions.WaitForFile(_pathProvider.DatabasePath, FileMode.Open, FileAccess.ReadWrite, FileShare.None)?.Dispose();
+            StreamExtensions.WaitForFile(PathProvider.DatabasePath, FileMode.Open, FileAccess.ReadWrite, FileShare.None)?.Dispose();
 
-            foreach (var databaseFilePath in _pathProvider.DatabaseFiles)
+            foreach (var databaseFilePath in PathProvider.DatabaseFiles)
             {
                 if (File.Exists(databaseFilePath))
                 {

--- a/src/Environment/Extensions/EnvironmentExtensions.cs
+++ b/src/Environment/Extensions/EnvironmentExtensions.cs
@@ -24,26 +24,17 @@ public static class EnvironmentExtensions
     /// <summary>
     /// This is the path that is used to store the /config, /downloads, /movies and /tvshows folders required to boot PlexRipper in development mode in a non-docker environment.
     /// </summary>
-    /// <returns></returns>
-    public static string? GetDevelopmentRootPath() => System.Environment.GetEnvironmentVariable(DevelopmentRootPathKey);
+    public static string? GetDevelopmentRootPath() => System.Environment.GetEnvironmentVariable("DEVELOPMENT_ROOT_PATH");
 
     /// <summary>
     /// Get root path from env variable so we can adjust it per environment.
     /// </summary>
-    /// <returns></returns>
-    public static string? GetPlexRipperRootPath()
-    {
-        return System.Environment.GetEnvironmentVariable(PlexRipperRootPathKey);
-    }
+    public static string? GetPlexRipperRootPath() => System.Environment.GetEnvironmentVariable(PlexRipperRootPathKey);
 
     /// <summary>
     /// This is the path that is used to store the /config, /downloads, /movies and /tvshows folders required to boot PlexRipper in development mode in a non-docker environment.
     /// </summary>
-    /// <returns></returns>
-    public static string? GetUserHomeDirectoryPath()
-    {
-        return System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile);
-    }
+    public static string? GetUserHomeDirectoryPath() => System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile);
 
     #endregion
 

--- a/src/Environment/Extensions/EnvironmentExtensions.cs
+++ b/src/Environment/Extensions/EnvironmentExtensions.cs
@@ -9,6 +9,8 @@ public static class EnvironmentExtensions
 
     public const string DevelopmentRootPathKey = "DEVELOPMENT_ROOT_PATH";
 
+    public const string PlexRipperRootPathKey = "PLEXRIPPER_ROOT_PATH";
+
     private static readonly string TrueValue = Convert.ToString(true);
 
     #endregion
@@ -24,6 +26,24 @@ public static class EnvironmentExtensions
     /// </summary>
     /// <returns></returns>
     public static string? GetDevelopmentRootPath() => System.Environment.GetEnvironmentVariable(DevelopmentRootPathKey);
+
+    /// <summary>
+    /// Get root path from env variable so we can adjust it per environment.
+    /// </summary>
+    /// <returns></returns>
+    public static string? GetPlexRipperRootPath()
+    {
+        return System.Environment.GetEnvironmentVariable(PlexRipperRootPathKey);
+    }
+
+    /// <summary>
+    /// This is the path that is used to store the /config, /downloads, /movies and /tvshows folders required to boot PlexRipper in development mode in a non-docker environment.
+    /// </summary>
+    /// <returns></returns>
+    public static string? GetUserHomeDirectoryPath()
+    {
+        return System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile);
+    }
 
     #endregion
 

--- a/src/Environment/Extensions/EnvironmentExtensions.cs
+++ b/src/Environment/Extensions/EnvironmentExtensions.cs
@@ -7,8 +7,6 @@ public static class EnvironmentExtensions
 
     public const string IntegrationTestModeKey = "IntegrationTestMode";
 
-    public const string DevelopmentRootPathKey = "DEVELOPMENT_ROOT_PATH";
-
     public const string PlexRipperRootPathKey = "PLEXRIPPER_ROOT_PATH";
 
     private static readonly string TrueValue = Convert.ToString(true);
@@ -22,16 +20,14 @@ public static class EnvironmentExtensions
     public static bool IsIntegrationTestMode() => System.Environment.GetEnvironmentVariable(IntegrationTestModeKey) == TrueValue;
 
     /// <summary>
-    /// This is the path that is used to store the /config, /downloads, /movies and /tvshows folders required to boot PlexRipper in development mode in a non-docker environment.
+    /// When a PlexRipperRootPath is set, it will be used as the root directory for the application.
     /// </summary>
-    public static string? GetDevelopmentRootPath() => System.Environment.GetEnvironmentVariable("DEVELOPMENT_ROOT_PATH");
+    public static string? GetPlexRipperRootPathEnv() => System.Environment.GetEnvironmentVariable(PlexRipperRootPathKey);
 
     /// <summary>
-    /// Get root path from env variable so we can adjust it per environment.
+    ///  Returns the path to the application directory bases on the current OS.
     /// </summary>
-    public static string? GetPlexRipperRootPath() => System.Environment.GetEnvironmentVariable(PlexRipperRootPathKey);
-
-    public static string? GetUserHomeDirectoryPath() => System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile);
+    public static string GetApplicationDirectoryPath() => System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData);
 
     #endregion
 

--- a/src/Environment/Extensions/EnvironmentExtensions.cs
+++ b/src/Environment/Extensions/EnvironmentExtensions.cs
@@ -31,9 +31,6 @@ public static class EnvironmentExtensions
     /// </summary>
     public static string? GetPlexRipperRootPath() => System.Environment.GetEnvironmentVariable(PlexRipperRootPathKey);
 
-    /// <summary>
-    /// This is the path that is used to store the /config, /downloads, /movies and /tvshows folders required to boot PlexRipper in development mode in a non-docker environment.
-    /// </summary>
     public static string? GetUserHomeDirectoryPath() => System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile);
 
     #endregion

--- a/src/Environment/Interfaces/IPathProvider.cs
+++ b/src/Environment/Interfaces/IPathProvider.cs
@@ -22,5 +22,5 @@ public interface IPathProvider
 
     string RootDirectory { get; }
 
-    List<string> DatabaseFiles { get; }
+    static List<string> DatabaseFiles { get; }
 }

--- a/src/Environment/PathProvider.cs
+++ b/src/Environment/PathProvider.cs
@@ -12,6 +12,8 @@ public class PathProvider : IPathProvider
 
     private static readonly string _logsFolder = "Logs";
 
+    public static string DefaultRootSubDirectory => "PlexRipper";
+
     public static string DefaultMovieDestinationFolder => "Movies";
 
     public static string DefaultDownloadsDestinationFolder => "Downloads";
@@ -60,16 +62,44 @@ public class PathProvider : IPathProvider
             if (devRootPath is not null)
                 return devRootPath;
 
+            string rootPath = "/";
+
             switch (OsInfo.CurrentOS)
             {
                 case OperatingSystemPlatform.Linux:
                 case OperatingSystemPlatform.Osx:
-                    return "/";
+
+                    string PlexRipperEnvRootPath = EnvironmentExtensions.GetPlexRipperRootPath();
+                    string HomeDirectory = EnvironmentExtensions.GetUserHomeDirectoryPath();
+
+                    if (PlexRipperEnvRootPath is not null)
+                    {
+                        rootPath = PlexRipperEnvRootPath;
+                        break;
+                    }
+
+                    if (HomeDirectory is not null)
+                    {
+                        rootPath = Path.Combine(HomeDirectory, DefaultRootSubDirectory);
+                        break;
+                    }
+
+                    rootPath = Path.Combine("/", DefaultRootSubDirectory);
+                    break;
                 case OperatingSystemPlatform.Windows:
-                    return Path.GetPathRoot(Assembly.GetExecutingAssembly().Location) ?? @"C:\";
+                    rootPath = Path.GetPathRoot(Assembly.GetExecutingAssembly().Location) ?? @"C:\";
+                    break;
                 default:
-                    return "/";
+                    rootPath = "/";
+                    break;
             }
+
+            if (!System.IO.Directory.Exists(rootPath))
+            {
+                Directory.CreateDirectory(rootPath);
+            }
+
+            return rootPath;
         }
     }
 

--- a/src/Environment/PathProvider.cs
+++ b/src/Environment/PathProvider.cs
@@ -94,11 +94,6 @@ public class PathProvider : IPathProvider
                     break;
             }
 
-            if (!Directory.Exists(rootPath))
-            {
-                Directory.CreateDirectory(rootPath);
-            }
-
             return rootPath;
         }
     }

--- a/src/Environment/PathProvider.cs
+++ b/src/Environment/PathProvider.cs
@@ -62,15 +62,15 @@ public class PathProvider : IPathProvider
             if (devRootPath is not null)
                 return devRootPath;
 
-            string rootPath = "/";
+            var rootPath = "/";
 
             switch (OsInfo.CurrentOS)
             {
                 case OperatingSystemPlatform.Linux:
                 case OperatingSystemPlatform.Osx:
 
-                    string PlexRipperEnvRootPath = EnvironmentExtensions.GetPlexRipperRootPath();
-                    string HomeDirectory = EnvironmentExtensions.GetUserHomeDirectoryPath();
+                    var PlexRipperEnvRootPath = EnvironmentExtensions.GetPlexRipperRootPath();
+                    var HomeDirectory = EnvironmentExtensions.GetUserHomeDirectoryPath();
 
                     if (PlexRipperEnvRootPath is not null)
                     {
@@ -94,7 +94,7 @@ public class PathProvider : IPathProvider
                     break;
             }
 
-            if (!System.IO.Directory.Exists(rootPath))
+            if (!Directory.Exists(rootPath))
             {
                 Directory.CreateDirectory(rootPath);
             }

--- a/src/Environment/PathProvider.cs
+++ b/src/Environment/PathProvider.cs
@@ -99,12 +99,12 @@ public class PathProvider : IPathProvider
 
     string IPathProvider.ConfigDirectory => ConfigDirectory;
 
-    public List<string> DatabaseFiles => new()
-    {
+    public static List<string> DatabaseFiles =>
+    [
         DatabasePath,
         Database_SHM_Path,
         Database_WAL_Path,
-    };
+    ];
 
     #endregion
 

--- a/src/Environment/PathProvider.cs
+++ b/src/Environment/PathProvider.cs
@@ -1,6 +1,4 @@
-﻿using System.Reflection;
-
-namespace Environment;
+﻿namespace Environment;
 
 public class PathProvider : IPathProvider
 {
@@ -58,43 +56,22 @@ public class PathProvider : IPathProvider
     {
         get
         {
-            var devRootPath = EnvironmentExtensions.GetDevelopmentRootPath();
-            if (devRootPath is not null)
-                return devRootPath;
+            var rootPath = EnvironmentExtensions.GetPlexRipperRootPathEnv();
+            if (rootPath is not null)
+                return rootPath;
 
-            var rootPath = "/";
-
+            // Determine the root path based on the current OS
             switch (OsInfo.CurrentOS)
             {
                 case OperatingSystemPlatform.Linux:
                 case OperatingSystemPlatform.Osx:
+                    return Path.Combine(EnvironmentExtensions.GetApplicationDirectoryPath(), DefaultRootSubDirectory);
 
-                    var PlexRipperEnvRootPath = EnvironmentExtensions.GetPlexRipperRootPath();
-                    var HomeDirectory = EnvironmentExtensions.GetUserHomeDirectoryPath();
-
-                    if (PlexRipperEnvRootPath is not null)
-                    {
-                        rootPath = PlexRipperEnvRootPath;
-                        break;
-                    }
-
-                    if (HomeDirectory is not null)
-                    {
-                        rootPath = Path.Combine(HomeDirectory, DefaultRootSubDirectory);
-                        break;
-                    }
-
-                    rootPath = Path.Combine("/", DefaultRootSubDirectory);
-                    break;
                 case OperatingSystemPlatform.Windows:
-                    rootPath = Path.GetPathRoot(Assembly.GetExecutingAssembly().Location) ?? @"C:\";
-                    break;
+                    return Path.Combine(EnvironmentExtensions.GetApplicationDirectoryPath(), DefaultRootSubDirectory);
                 default:
-                    rootPath = "/";
-                    break;
+                    return "/";
             }
-
-            return rootPath;
         }
     }
 

--- a/src/WebAPI/Program.cs
+++ b/src/WebAPI/Program.cs
@@ -15,6 +15,9 @@ public class Program
             LogManager.SetupLogging(LogEventLevel.Verbose);
             _log.Information("Currently running on {CurrentOS}", OsInfo.CurrentOS);
 
+            _log.Information("Root directory: {RootDirectory}", PathProvider.RootDirectory);
+            _log.InformationLine("The Root directory can be set by passing in the \'PLEXRIPPER_ROOT_PATH\' env value with a valid folder path");
+
             var builder = WebApplication.CreateBuilder(args);
 
             builder.ConfigureDatabase();

--- a/src/WebAPI/Startup.cs
+++ b/src/WebAPI/Startup.cs
@@ -182,9 +182,9 @@ public static class Startup
         services.RemoveAll<IHttpMessageHandlerBuilderFilter>();
     }
 
-    public static void ConfigureDatabase(this WebApplicationBuilder builder)
+    public static void ConfigureDatabase(this WebApplicationBuilder _)
     {
-        var dbContext = new PlexRipperDbContext(new PathProvider());
+        var dbContext = new PlexRipperDbContext();
         dbContext.Setup();
     }
 }


### PR DESCRIPTION
Implemented more flexibility in changing the root directory for PlexRipper.

By default, Plexripper placed it's directories directly under /. 
This PR has the following logic.

* If PLEXRIPPER_ROOT_DIR env variable is set, use that as the path for the root direcotry, do not append the default subdir
* if we can detect a user Home directory from env variables, use the home directory/subdir as root dir.
* by default it still falls back to / but the default subdir is appended so we get /PlexRipper/Movies.

This goes for Linux/OSX but should also be implemented for Windows, with maybe different logic.

The default subdirectory I added is to ensure we don't automatically spread our folders in other directories, but rather stay together unless otherwise defined. This is a experimental PR which is not finished or properly tested yet.
