### PR TITLE
ci: Add docker metadata

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -56,6 +56,16 @@ jobs:
                     username: ${{ secrets.DOCKER_USERNAME }}
                     password: ${{ secrets.DOCKER_PASSWORD }}
 
+            -   name: Docker meta
+                id: meta
+                uses: docker/metadata-action@v5
+                with:
+                    images: |
+                        name=plexripper/plexripper
+                    tags: |
+                        type=raw,value=${{ env.VERSION_WITH_DATE }}
+                        type=raw,value=dev
+
             -   name: Build and push
                 uses: docker/build-push-action@v6
                 env:
@@ -64,7 +74,8 @@ jobs:
                 with:
                     platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
                     push: true
-                    tags: plexripper/plexripper:dev,plexripper/plexripper:${{ env.VERSION_WITH_DATE }}
+                    tags: ${{ steps.meta.outputs.tags }}
+                    labels: ${{ steps.meta.outputs.labels }}
                     build-args: |
                         VERSION=${{ env.VERSION_NO_V }}
                         INFORMATIONAL_VERSION=${{ env.VERSION_WITH_DATE }}

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -76,6 +76,15 @@ jobs:
                     username: ${{ secrets.DOCKER_USERNAME }}
                     password: ${{ secrets.DOCKER_PASSWORD }}
 
+            -   name: Docker meta
+                id: meta
+                uses: docker/metadata-action@v5
+                with:
+                    images: |
+                        name=plexripper/plexripper
+                    tags: |
+                        type=semver,pattern={{version}},value=${{ env.VERSION_NO_V }}
+
             -   name: Build and push
                 uses: docker/build-push-action@v6
                 env:
@@ -84,7 +93,8 @@ jobs:
                 with:
                     platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
                     push: true
-                    tags: plexripper/plexripper:latest,plexripper/plexripper:${{ env.VERSION_NO_V }}
+                    tags: ${{ steps.meta.outputs.tags }}
+                    labels: ${{ steps.meta.outputs.labels }}
                     build-args: |
                         VERSION=${{ env.VERSION_NO_V }}
                         INFORMATIONAL_VERSION=${{ env.VERSION_NO_V }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -122,8 +122,10 @@ COPY --from=client-build /tmp/ClientApp/.output/public /app/wwwroot
 COPY docker/etc/ /etc/
 
 ## Set version label
-LABEL company="PlexRipper"
-LABEL maintainer="plexripper@protonmail.com"
+LABEL company="PlexRipper" \
+    maintainer="plexripper@protonmail.com" \
+    org.opencontainers.image.authors="PlexRipper" \
+    org.opencontainers.image.vendor="PlexRipper"
 
 EXPOSE ${PORT}
 VOLUME /Config /Downloads /Movies /TvShows

--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -113,8 +113,10 @@ COPY --from=client-build /tmp/ClientApp/.output/public /app/wwwroot
 COPY docker/etc/ /etc/
 
 ## Set version label
-LABEL company="PlexRipper"
-LABEL maintainer="plexripper@protonmail.com"
+LABEL company="PlexRipper" \
+    maintainer="plexripper@protonmail.com" \
+    org.opencontainers.image.authors="PlexRipper" \
+    org.opencontainers.image.vendor="PlexRipper"
 
 EXPOSE ${PORT}
 VOLUME /Config /Downloads /Movies /TvShows


### PR DESCRIPTION
Tools like Renovate and Dependabot use docker labels to determine changelogs from release notes.

The current metadata points mostly to linuxserver so the tools are confused and are not able to provide release notes.

```
regctl image config --format '{{ jsonPretty .Config.Labels }}' plexripper/plexripper
{
  "build_version": "Linuxserver.io version:- 1ead795c-ls18 Build-date:- 2025-01-10T19:42:29+00:00",
  "company": "PlexRipper",
  "maintainer": "plexripper@protonmail.com",
  "org.opencontainers.image.authors": "linuxserver.io",
  "org.opencontainers.image.created": "2025-01-10T19:42:29+00:00",
  "org.opencontainers.image.description": "baseimage-alpine image by linuxserver.io",
  "org.opencontainers.image.documentation": "https://docs.linuxserver.io/images/docker-baseimage-alpine",
  "org.opencontainers.image.licenses": "GPL-3.0-only",
  "org.opencontainers.image.ref.name": "b1bf7ab635a445c1e2c284cadad3e9bacc7410aa",
  "org.opencontainers.image.revision": "b1bf7ab635a445c1e2c284cadad3e9bacc7410aa",
  "org.opencontainers.image.source": "https://github.com/linuxserver/docker-baseimage-alpine",
  "org.opencontainers.image.title": "Baseimage-alpine",
  "org.opencontainers.image.url": "https://github.com/linuxserver/docker-baseimage-alpine/packages",
  "org.opencontainers.image.vendor": "linuxserver.io",
  "org.opencontainers.image.version": "1ead795c-ls18"
}
```