### PR TITLE
FIX: wrong available size calculation for docker mounts

### DIFF
--- a/src/FileSystem.Contracts/Extensions/IPathSystemExtensions.cs
+++ b/src/FileSystem.Contracts/Extensions/IPathSystemExtensions.cs
@@ -9,13 +9,7 @@ public static class IPathExtensions
     {
         try
         {
-            var f = new FileInfo(directory);
-
-            var root = path.GetPathRoot(f.FullName);
-            if (string.IsNullOrEmpty(root))
-                return Result.Fail($"Could not determine root directory of {directory}");
-
-            var drive = path.FileSystem.DriveInfo.New(root);
+            var drive = path.FileSystem.DriveInfo.New(directory);
             return Result.Ok(drive.AvailableFreeSpace);
         }
         catch (Exception e)

--- a/tests/BaseTests/Common/BaseUnitTest/BaseUnitTest.MockDependencies.cs
+++ b/tests/BaseTests/Common/BaseUnitTest/BaseUnitTest.MockDependencies.cs
@@ -33,6 +33,10 @@ public partial class BaseUnitTest : IDisposable
             {
                 SetDefaultFileSystemDirectories();
                 _fileSystemSetup.Invoke(builder);
+
+                builder.Register(ctx => ctx.Resolve<IFileSystem>().Path).As<IPath>().SingleInstance();
+                builder.Register(ctx => ctx.Resolve<IFileSystem>().File).As<IFile>().SingleInstance();
+                builder.Register(ctx => ctx.Resolve<IFileSystem>().Directory).As<IDirectory>().SingleInstance();
             }
 
             if (_httpClientSetup is not null)
@@ -81,10 +85,6 @@ public partial class BaseUnitTest : IDisposable
 
         builder.RegisterType<Log>().As<ILog>().SingleInstance();
         builder.RegisterGeneric(typeof(Log<>)).As(typeof(ILog<>)).InstancePerDependency();
-
-        builder.Register(ctx => ctx.Resolve<IFileSystem>().Path).As<IPath>().SingleInstance();
-        builder.Register(ctx => ctx.Resolve<IFileSystem>().File).As<IFile>().SingleInstance();
-        builder.Register(ctx => ctx.Resolve<IFileSystem>().Directory).As<IDirectory>().SingleInstance();
     }
 
     protected void SetupHttpClient(Action<Mock<HttpMessageHandler>>? action = null)

--- a/tests/BaseTests/Common/BaseUnitTest/BaseUnitTest.MockDependencies.cs
+++ b/tests/BaseTests/Common/BaseUnitTest/BaseUnitTest.MockDependencies.cs
@@ -21,6 +21,8 @@ public partial class BaseUnitTest : IDisposable
     private readonly MockFileSystem _fileSystem = new();
     protected AutoMock mock { get; set; }
 
+    protected long DefaultAvailableSpace = (long)ByteSize.FromGigaBytes(1000).Bytes;
+
     private void Build()
     {
         mock = AutoMock.GetStrict(builder =>
@@ -111,7 +113,7 @@ public partial class BaseUnitTest : IDisposable
             {
                 IsReady = true,
                 DriveType = DriveType.Fixed,
-                AvailableFreeSpace = (long)ByteSize.FromGigaBytes(1000).Bytes,
+                AvailableFreeSpace = DefaultAvailableSpace,
             }
         );
         _fileSystem.AddDirectory(PathProvider.ConfigDirectory);

--- a/tests/UnitTests/FileSystem.UnitTests/FileSystemExtensions/IFileSystemExtensions.UnitTests.cs
+++ b/tests/UnitTests/FileSystem.UnitTests/FileSystemExtensions/IFileSystemExtensions.UnitTests.cs
@@ -1,6 +1,6 @@
 using System.IO.Abstractions;
 using Autofac;
-using ByteSizeLib;
+using Environment;
 using FileSystem.Contracts;
 
 namespace FileSystem.UnitTests.FileSystemExtensions;
@@ -25,6 +25,65 @@ public class IFileSystemExtensionsUnitTests : BaseUnitTest
         // Assert
         result.ShouldNotBeNull();
         result.IsSuccess.ShouldBeTrue();
-        result.Value.ShouldBe((long)ByteSize.FromGigaBytes(1000).Bytes);
+        result.Value.ShouldBe(DefaultAvailableSpace);
+    }
+
+    [Fact]
+    public void ShouldReturnCorrectAvailableSpace_WhenUsingTheMoviesPath()
+    {
+        // Arrange
+        var path = PathProvider.DefaultMovieDestinationFolder;
+
+        SetupFileSystem(system =>
+        {
+            system.AddDirectory(path);
+        });
+
+        // Act
+        var sut = mock.Container.Resolve<IPath>();
+        var result = sut.GetAvailableSpaceByDirectory(path);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.ShouldBe(DefaultAvailableSpace);
+    }
+
+    [Fact]
+    public void ShouldReturnCorrectAvailableSpace_WhenUsingACustomFolder()
+    {
+        // Arrange
+        var path = "/SomeCustomFolder";
+
+        SetupFileSystem(system =>
+        {
+            system.AddDirectory(path);
+        });
+
+        // Act
+        var sut = mock.Container.Resolve<IPath>();
+        var result = sut.GetAvailableSpaceByDirectory(path);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.ShouldBe(DefaultAvailableSpace);
+    }
+
+    [Fact]
+    public void ShouldReturnFailedResult_WhenUsingAFolderThatDoesNotExist()
+    {
+        // Arrange
+        var path = @"C:\FolderDoesNotExist";
+
+        SetupFileSystem();
+
+        // Act
+        var sut = mock.Container.Resolve<IPath>();
+        var result = sut.GetAvailableSpaceByDirectory(path);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.IsSuccess.ShouldBeFalse();
     }
 }


### PR DESCRIPTION
I had issues due to the app reporting not having enough space left.

This is due to trying to get the "root" / "drive" but on unix this always reports "/" and within the docker container that's just the docker filesystem and not anything that might be mounted into the container.

also the default `DriveInfo()` already fans back to the correct drive on Windows and works correctly in a container.

https://learn.microsoft.com/en-us/dotnet/api/system.io.driveinfo.-ctor?view=net-9.0#remarks
> On Windows, passing a mounted directory (for example, C:\NetworkMountedDrive) obtains information for the root drive (for example, C:).

I was not able to verify the fix within PlexRipper as docker build keep failing locally  
