### PR TITLE
Applies fix for #469, ambiguity

### DIFF
--- a/src/Domain/Extensions/HttpRequestMessageExtensions.cs
+++ b/src/Domain/Extensions/HttpRequestMessageExtensions.cs
@@ -18,11 +18,11 @@ public static class HttpRequestMessageExtensions
             query = query.Substring(1);
 
         // Split the query string by '&'
-        var pairs = query.Split(['&'], StringSplitOptions.RemoveEmptyEntries);
+        var pairs = query.Split(new[] { '&' }, StringSplitOptions.RemoveEmptyEntries);
         foreach (var pair in pairs)
         {
             // Split each pair by '='. Use a count of 2 so that values containing '=' are preserved.
-            var parts = pair.Split(['='], 2);
+            var parts = pair.Split(new[] { '=' }, 2);
             if (parts.Length >= 1)
             {
                 // Decode key and value


### PR DESCRIPTION
This pull request includes a minor update to the `ParseQueryToDictionary` method in `HttpRequestMessageExtensions.cs` to improve compatibility and readability.

* [`src/Domain/Extensions/HttpRequestMessageExtensions.cs`](diffhunk://#diff-ba8c5d0f476f33f4e4d6828ae133617df8ec8ad6be7b9e2f1ebd594a25f03698L21-R25): Updated the `Split` method calls to use `new[]` syntax instead of array literals for splitting query strings and key-value pairs.

Fixes #469 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated code style for splitting query strings; no changes to user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->