### PR TITLE
fix(WebAPI): Add download parameter to download URL, this might in some cases fix an empty download response

### DIFF
--- a/src/Domain/Entities/Plex/PlexServerConnection.cs
+++ b/src/Domain/Entities/Plex/PlexServerConnection.cs
@@ -64,7 +64,7 @@ public class PlexServerConnection : BaseEntity
     public bool IsHttps => Protocol.Equals("https", StringComparison.OrdinalIgnoreCase);
 
     public string GetDownloadUrl(string fileLocationUrl, string token) =>
-        $"{Url}{fileLocationUrl}?X-Plex-Token={token}";
+        $"{Url}{fileLocationUrl}?X-Plex-Token={token}&download=1";
 
     public PlexConnectionTypes Type
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved download functionality for Plex server integration to ensure files are properly requested with the correct parameters for direct retrieval.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->