### PR TITLE
fix(docker): use PUID/PGID ownership for /Config

### DIFF
--- a/docker/etc/s6-overlay/s6-rc.d/reaparr/run
+++ b/docker/etc/s6-overlay/s6-rc.d/reaparr/run
@@ -20,12 +20,14 @@ if [[ -z ${LSIO_NON_ROOT_USER} ]]; then
     CURRENT_GID=$(stat -c %g /Config 2>/dev/null || echo "unknown")
     echo "/Config ownership before fix: uid=${CURRENT_UID} gid=${CURRENT_GID} (target uid=${PUID} gid=${PGID})"
 
+    TARGET_OWNER="${PUID}:${PGID}"
+
     if [[ ! "${CURRENT_UID}" == "${PUID}" ]] || [[ ! "${CURRENT_GID}" == "${PGID}" ]]; then
-        echo "Change in ownership detected for /Config, applying ownership fix"
-        lsiown -R abc:abc /Config
+        echo "Change in ownership detected for /Config, applying ownership fix to ${TARGET_OWNER}"
+        lsiown -R "${TARGET_OWNER}" /Config
     fi
 
-    lsiown abc:abc /Config
+    lsiown "${TARGET_OWNER}" /Config
 
     NEW_UID=$(stat -c %u /Config 2>/dev/null || echo "unknown")
     NEW_GID=$(stat -c %g /Config 2>/dev/null || echo "unknown")

--- a/plans/media-overview-paged-virtual-scroll-alphabet-jump.md
+++ b/plans/media-overview-paged-virtual-scroll-alphabet-jump.md
@@ -1,0 +1,1303 @@
+# Media Overview Paged Virtual Scroll + Sort Navigation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `executing-plans` to implement this plan task-by-task. For Reaparr frontend work, always load `reaparr-frontend-components`; for Pinia store changes, also load `reaparr-pinia-store`. For Reaparr backend work, always load `reaparr-backend` before narrower backend skills such as `fast-endpoints`, `entity-framework-core`, and `reaparr-backend-unit-tests`. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace Media Overview’s load-all behavior with server-backed pagination, sparse client caching, seamless virtual scrolling, and accurate sort-aware navigation labels across very large libraries.
+
+**Architecture:** TanStack Virtual remains responsible only for viewport virtualization, placeholder rendering, range observation, and `scrollToIndex`. The Reaparr backend becomes authoritative for active-query filtering, search, sorting, total matching count, page windows, and navigation label-to-global-index anchors. The frontend store keeps a sparse page cache keyed by global item index/page and loads missing ranges on demand, including a centered range around navigation jumps.
+
+**Tech Stack:** ASP.NET Core / FastEndpoints, EF Core, C#, Vue 3, Nuxt SPA, Pinia, RxJS, `@tanstack/vue-virtual`, Quasar.
+
+---
+
+## Critical Findings From Investigation
+
+Files already inspected during planning/investigation:
+
+- `src/AppHost/ClientApp/src/store/mediaOverviewStore.ts`
+- `src/AppHost/ClientApp/src/components/MediaOverview/MediaOverview.vue`
+- `src/AppHost/ClientApp/src/components/Navigation/AlphabetNavigation.vue`
+- `src/AppHost/ClientApp/src/components/MediaOverview/MediaTable/MediaTable.vue`
+- `src/AppHost/ClientApp/src/components/MediaOverview/PosterTable/PosterTable.vue`
+- `src/AppHost/ClientApp/src/components/MediaOverview/MediaOverviewSearchBar.vue`
+- `src/AppHost/ClientApp/src/types/enums/mediaSortField.ts`
+- `src/AppHost/ClientApp/src/types/api/generated/PlexLibrary.ts`
+- `src/Application/PlexLibraries/GetMetadata/GetLibraryMediaMetadata.cs`
+- `src/Application/PlexLibraries/GetMedia/GetPlexLibraryMediaEndpoint.cs`
+- `src/Application/PlexMedia/GetAll/GetAllMediaByTypeEndpoint.cs`
+- `src/Application/_Shared/BaseRequests/PlexMediaFilterQueryRequest.cs`
+- `src/Data.Contracts/DTO/MediaQueryFilter.cs`
+- `src/Data.Contracts/Extensions/DbContext/DbContextExtensions.PlexMedia.cs`
+- `src/Application.Contracts/_Shared/Mappings/PlexMedia/DTO/PlexMediaMetadataDTO.cs`
+- `src/Application.Contracts/_Shared/Mappings/PlexMedia/DTO/PlexMediaStatisticsDTO.cs`
+- `src/Application.Contracts/_Shared/Mappings/PlexMedia/PlexMediaSlimDTOMapper.cs`
+
+### Current frontend behavior
+
+Files already inspected in the planning session:
+
+- `src/AppHost/ClientApp/src/store/mediaOverviewStore.ts`
+- `src/AppHost/ClientApp/src/components/MediaOverview/MediaOverview.vue`
+- `src/AppHost/ClientApp/src/components/Navigation/AlphabetNavigation.vue`
+- `src/AppHost/ClientApp/src/components/MediaOverview/MediaTable/MediaTable.vue`
+- `src/AppHost/ClientApp/src/components/MediaOverview/PosterTable/PosterTable.vue`
+
+Current flow:
+
+1. `mediaOverviewStore.requestMedia()` uses `page = 0` and `size = 0`.
+2. It calls either `refreshAllLibraryMediaByType(page, size)` or `refreshLibraryMedia(page, size)`.
+3. `setMedia(data)` stores all returned media in `state.items = Object.freeze(data.mediaList)`.
+4. `AlphabetNavigation.vue` renders `mediaOverviewStore.scrollDict`.
+5. `scrollDict` is generated from currently loaded items in `setMediaIndexNavigationOptions()`.
+6. `sortMedia()` sorts the full loaded list client-side into `state.sortedItems`.
+7. `getMediaItems` filters locally using `state.filterQuery`.
+8. `MediaTable.vue` and `PosterTable.vue` receive an index through the event bus and call TanStack Virtual `scrollToIndex`.
+
+This works only because all items are loaded. With true pagination, search, sort, and navigation labels must be server-backed. `scrollDict` can no longer be derived from loaded client items.
+
+### Existing backend metadata endpoint
+
+`src/Application/PlexLibraries/GetMetadata/GetLibraryMediaMetadata.cs` currently returns `PlexMediaMetadataDTO` containing media/filter metadata including `MediaCount`, role/country/genre/quality counts, and filter lists. This endpoint is still the right place to return navigation metadata because it represents the active media overview context.
+
+However, the navigation contract must be generic, not alphabet-only. The frontend sort mode is always representable as a displayed `label => first global index` mapping. Replace the original alphabet-only idea with a generic property such as:
+
+```csharp
+public Dictionary<string, int> NavigationIndexes { get; init; } = [];
+```
+
+Examples:
+
+- Title sort: `# => 0`, `A => 3`, `B => 20`
+- Year sort: `2024 => 0`, `2023 => 18`
+- Quality sort: `1080p => 0`, `720p => 150`
+- Duration sort: `0–10 min => 0`, `10–20 min => 30`
+- Media size sort: `0–1 GB => 0`, `1–2 GB => 84`
+- Date sort: `Jan 2024 => 0`, `Dec 2023 => 44`
+
+### Current backend paging contract gap
+
+The existing paged endpoints are:
+
+- `src/Application/PlexLibraries/GetMedia/GetPlexLibraryMediaEndpoint.cs`
+- `src/Application/PlexMedia/GetAll/GetAllMediaByTypeEndpoint.cs`
+
+Both call `_dbContext.GetMediaByType(...)`, which returns only the requested page/list as `List<PlexMediaSlimDTO>`. The response is currently built through `ToStatisticsDTO()`, and `ToStatisticsDTO()` calculates `MediaCount` by iterating only the returned list. Therefore, after paging is enabled, `PlexMediaStatisticsDTO.MediaCount` means **returned page count**, not **total matching active-query count**.
+
+Virtualizer `count` must never depend on this ambiguous page count. Add an explicit `TotalCount` property to the paged media response and make the frontend use `totalCount` for virtualization.
+
+### Current all-media sorting bug for deep paging
+
+`GetMediaByType(...)` currently applies DB `Skip/Take`, then for all-media mode (`plexLibraryId == 0`) sorts only the returned page with:
+
+```csharp
+plexMediaSlimDtos = plexMediaSlimDtos.OrderByNatural(x => x.SearchTitle).ToList();
+```
+
+That is not globally sorted pagination. Correct order must be:
+
+```text
+base query -> filters -> search -> sort -> total count -> skip/take -> DTO projection
+```
+
+---
+
+## Target UX
+
+### Infinite scroll
+
+- Initial page loads quickly.
+- Virtualizer `count` equals total matching media count, not loaded item count.
+- Visible unloaded rows render as placeholders/skeletons.
+- As the user scrolls, the store fetches missing pages around the visible range.
+- Loaded pages are inserted into the local sparse cache.
+
+### Sort-aware navigation jump
+
+When the user clicks a navigation label:
+
+1. `AlphabetNavigation` sends a jump command for the backend-provided global index.
+2. Store requests a range around the index, for example 50 items before and after.
+3. Store inserts returned pages/items into the sparse cache.
+4. Component calls TanStack Virtual `scrollToIndex(globalIndex)`.
+5. Row/poster appears with minimal delay and is highlighted.
+
+The component may keep its existing name `AlphabetNavigation.vue` during migration, but the data is now generic sort navigation, not alphabet-only data. A later cleanup may rename the component.
+
+### TanStack Virtual conclusion
+
+`@tanstack/vue-virtual` supports the needed viewport mechanics: large `count`, `scrollToIndex`, range observation through `onChange`, placeholders for unloaded indexes, and fixed or dynamic item sizes. It does not provide remote pagination, query anchors, or server-side indexes. Those belong in Reaparr’s API and Pinia store.
+
+---
+
+# Phase 1: Backend query contract foundation
+
+## Task 1: Add explicit active-query total count to paged media response
+
+**Files:**
+
+- Modify: `src/Application.Contracts/_Shared/Mappings/PlexMedia/DTO/PlexMediaStatisticsDTO.cs`
+- Modify: `src/Application.Contracts/_Shared/Mappings/PlexMedia/PlexMediaSlimDTOMapper.cs`
+- Test: existing Application unit tests covering media endpoints, or add focused tests in `tests/UnitTests/Application.UnitTests/`
+
+- [ ] **Step 1: Add `TotalCount` to `PlexMediaStatisticsDTO`**
+
+Add an explicit active-query total count separate from the page statistics:
+
+```csharp
+public class PlexMediaStatisticsDTO
+{
+    /// <summary>
+    /// Gets or sets the total number of media items matching the active query before paging.
+    /// This value is used by the frontend virtualizer.
+    /// </summary>
+    public required int TotalCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the count of media items in this returned page/list.
+    /// </summary>
+    public required int MediaCount { get; set; }
+
+    public required int MovieCount { get; set; }
+
+    public required int TvShowCount { get; set; }
+
+    public required int SeasonCount { get; set; }
+
+    public required int EpisodeCount { get; set; }
+
+    public required long MediaSize { get; set; }
+
+    public required List<PlexMediaSlimDTO> MediaList { get; init; }
+}
+```
+
+- [ ] **Step 2: Update `ToStatisticsDTO` to accept an optional total count**
+
+Change the mapper signature to avoid ambiguous totals:
+
+```csharp
+public static PlexMediaStatisticsDTO ToStatisticsDTO(this List<PlexMediaSlimDTO> source, int? totalCount = null)
+{
+    var stats = new PlexMediaStatisticsDTO
+    {
+        TotalCount = totalCount ?? source.Count,
+        MovieCount = 0,
+        TvShowCount = 0,
+        SeasonCount = 0,
+        EpisodeCount = 0,
+        MediaSize = 0,
+        MediaCount = 0,
+        MediaList = source,
+    };
+
+    // Existing page statistics calculation remains the same.
+}
+```
+
+- [ ] **Step 3: Update all object initializers and call sites**
+
+Search for `new PlexMediaStatisticsDTO` and `ToStatisticsDTO(`. Ensure every initializer sets `TotalCount`, and every paged endpoint passes the active query total once available. During this task, legacy call sites may use `source.Count` via the mapper default.
+
+- [ ] **Step 4: Run Rider diagnostics for changed backend files**
+
+Expected: no errors.
+
+---
+
+## Task 2: Extend query request/filter contracts with search and server-side sort
+
+**Files:**
+
+- Modify: `src/Application/_Shared/BaseRequests/PlexMediaFilterQueryRequest.cs`
+- Modify: `src/Data.Contracts/DTO/MediaQueryFilter.cs`
+- Modify: endpoint request call sites using `MediaQueryFilter`
+- Test: relevant Application endpoint validator tests
+
+- [ ] **Step 1: Extend `PlexMediaFilterQueryRequest`**
+
+Add query parameters that reflect the frontend query context. Use existing frontend sort values from `src/AppHost/ClientApp/src/types/enums/mediaSortField.ts`:
+
+```csharp
+[QueryParam, BindFrom("search")]
+[DefaultValue("")]
+public string Search { get; init; } = string.Empty;
+
+[QueryParam, BindFrom("sortField")]
+[DefaultValue("sortIndex")]
+public string SortField { get; init; } = "sortIndex";
+
+[QueryParam, BindFrom("sortDirection")]
+[DefaultValue("asc")]
+public string SortDirection { get; init; } = "asc";
+```
+
+Update the protected constructor to accept and assign these values so generated TypeScript treats them as query params.
+
+- [ ] **Step 2: Extend `MediaQueryFilter`**
+
+Add:
+
+```csharp
+public required string Search { get; init; }
+
+public required string SortField { get; init; }
+
+public required string SortDirection { get; init; }
+```
+
+- [ ] **Step 3: Pass query fields from endpoints into `MediaQueryFilter`**
+
+Both `GetPlexLibraryMediaEndpoint` and `GetAllMediaByTypeEndpoint` must set:
+
+```csharp
+Search = req.Search,
+SortField = req.SortField,
+SortDirection = req.SortDirection,
+```
+
+- [ ] **Step 4: Validate supported sort direction and sort fields**
+
+Supported `SortDirection` values are `asc` and `desc`. Supported `SortField` values initially match frontend `MediaSortField` values:
+
+```text
+sortIndex
+year
+addedAt
+updatedAt
+duration
+mediaSize
+quality
+```
+
+- [ ] **Step 5: Run Rider diagnostics**
+
+Expected: no errors.
+
+---
+
+## Task 3: Refactor `GetMediaByType` to return page plus active total count
+
+**Files:**
+
+- Modify: `src/Data.Contracts/Extensions/DbContext/DbContextExtensions.PlexMedia.cs`
+- Optional create: `src/Data.Contracts/DTO/PagedMediaQueryResult.cs` if no suitable result type exists
+- Test: endpoint tests for page count vs total count
+
+- [ ] **Step 1: Introduce a result type for paged media query output**
+
+Create a small DTO/record in `src/Data.Contracts/DTO/` if one does not already exist:
+
+```csharp
+namespace Reaparr.Data.Contracts;
+
+public record PagedMediaQueryResult
+{
+    public required List<PlexMediaSlimDTO> Items { get; init; }
+
+    public required int TotalCount { get; init; }
+}
+```
+
+Prefer the existing `DTO` folder to avoid new folder registration.
+
+- [ ] **Step 2: Change `GetMediaByType` return type**
+
+Change:
+
+```csharp
+public static async Task<Result<List<PlexMediaSlimDTO>>> GetMediaByType(...)
+```
+
+to:
+
+```csharp
+public static async Task<Result<PagedMediaQueryResult>> GetMediaByType(...)
+```
+
+- [ ] **Step 3: Apply filter/search/sort before count and paging**
+
+The implementation order must be:
+
+```text
+base query -> allowed libraries -> metadata filters -> search -> sort -> CountAsync -> Skip/Take -> DTO projection
+```
+
+Do not sort after `Skip/Take`. This is especially important for all-media mode.
+
+- [ ] **Step 4: Keep first implementation simple but bounded**
+
+Prefer EF-translatable ordering and filtering. If natural sorting cannot be translated, use deterministic database-side ordering by `SearchTitle`/`SortIndex` for now and document natural-sort parity as a follow-up. Do not load 100k full DTOs solely to sort in memory.
+
+- [ ] **Step 5: Return page items and total count**
+
+Return:
+
+```csharp
+return Result.Ok(new PagedMediaQueryResult
+{
+    Items = plexMediaSlimDtos,
+    TotalCount = totalCount,
+});
+```
+
+- [ ] **Step 6: Update endpoints to pass total count into `ToStatisticsDTO`**
+
+Use:
+
+```csharp
+await SendFluentResult(
+    Result.Ok(mediaListResult.Value.Items.ToStatisticsDTO(mediaListResult.Value.TotalCount)),
+    ct
+);
+```
+
+- [ ] **Step 7: Run Rider diagnostics**
+
+Expected: no errors.
+
+---
+
+# Phase 2: Backend generic navigation indexes
+
+## Task 4: Replace alphabet-only metadata with generic navigation indexes
+
+**Files:**
+
+- Modify: `src/Application.Contracts/_Shared/Mappings/PlexMedia/DTO/PlexMediaMetadataDTO.cs`
+- Modify: `src/Application/PlexLibraries/GetMetadata/GetLibraryMediaMetadata.cs`
+- Test: metadata endpoint tests
+
+- [ ] **Step 1: Add `NavigationIndexes` to `PlexMediaMetadataDTO`**
+
+Add:
+
+```csharp
+/// <summary>
+/// Gets sort-aware navigation labels mapped to their first global index in the active filtered/searched/sorted result set.
+/// </summary>
+public Dictionary<string, int> NavigationIndexes { get; init; } = [];
+```
+
+Do not add `AlphabetIndexes`; this feature is not alphabet-only.
+
+- [ ] **Step 2: Extend `GetLibraryMediaMetadataRequest` with active query context**
+
+The metadata endpoint must accept enough query params to match the media page endpoint: `search`, `countryId`, `genreId`, `roleId`, `quality`, `filterOfflineMedia`, `filterOwnedMedia`, `sortField`, and `sortDirection`. Use the same bind names as the page endpoints.
+
+- [ ] **Step 3: Build a helper for `label => first global index`**
+
+Add a helper conceptually shaped like:
+
+```csharp
+private async Task<Dictionary<string, int>> GetNavigationIndexes(
+    GetLibraryMediaMetadataRequest req,
+    CancellationToken ct
+)
+{
+    // Build the same active query as the paged media endpoint.
+    // Apply filters/search/sort before indexing.
+    // Project only the fields required to calculate the label.
+    // Return the first global index for each displayed label.
+}
+```
+
+Do not load full media DTOs. If an initial implementation must calculate labels in memory, only project minimal scalar fields needed for labels and document the performance trade-off in a code comment.
+
+- [ ] **Step 4: Implement label functions that match the current frontend sort labels**
+
+Current frontend `setMediaIndexNavigationOptions()` behavior should move server-side. Use these label semantics:
+
+```text
+sortIndex/title: first character bucket, A-Z or #
+year: year or #
+quality: translated/highest quality label
+duration: 10-minute buckets, e.g. 0–10 min
+addedAt: MMM yyyy
+updatedAt: MMM yyyy
+mediaSize: decimal GB buckets, e.g. 0–1 GB
+```
+
+- [ ] **Step 5: Set `NavigationIndexes` in both metadata branches**
+
+Both the specific-library branch and all-media branch must set:
+
+```csharp
+NavigationIndexes = await GetNavigationIndexes(req, ct),
+```
+
+- [ ] **Step 6: Run Rider diagnostics**
+
+Expected: no errors.
+
+---
+
+# Phase 3: Generated frontend API update
+
+## Task 5: Regenerate TypeScript API from backend contracts
+
+**Files:**
+
+- Generated modify: `src/AppHost/ClientApp/src/types/api/generated/*`
+- Generated modify: API path helpers if changed
+
+- [ ] **Step 1: Start backend dev run configuration through Rider MCP**
+
+AGENTS.md requires the backend to be running before `generate-ts`. Use the Rider run configuration from `.run/Reaparr Back-End Development.run.xml` if available.
+
+- [ ] **Step 2: Run frontend generation through existing Bun tooling**
+
+Use the project script from `src/AppHost/ClientApp/package.json`. Expected command shape:
+
+```bash
+bun --cwd src/AppHost/ClientApp run generate-ts
+```
+
+Use MCP run tooling where available. Do not use npm/yarn/pnpm.
+
+- [ ] **Step 3: Confirm generated TypeScript contains new fields**
+
+Verify generated contracts include:
+
+```ts
+interface PlexMediaStatisticsDTO {
+  totalCount: number;
+}
+
+interface PlexMediaMetadataDTO {
+  navigationIndexes?: Record<string, number>;
+}
+```
+
+Exact optional/required syntax may differ depending on generator output.
+
+- [ ] **Step 4: If generation is blocked, stop and report**
+
+Do not silently hand-edit generated API files unless the user approves a temporary generated-file edit.
+
+---
+
+# Phase 4: Frontend store sparse cache
+
+## Task 6: Add sparse paging state to `mediaOverviewStore.ts`
+
+**Files:**
+
+- Modify: `src/AppHost/ClientApp/src/store/mediaOverviewStore.ts`
+
+- [ ] **Step 1: Add state fields**
+
+Add to `IMediaOverviewStoreState` and `defaultState`:
+
+```ts
+pageSize: number;
+totalCount: number;
+pageCache: Map<number, Readonly<PlexMediaSlimDTO[]>>;
+loadedPages: Set<number>;
+loadingPages: Set<number>;
+navigationIndexes: Map<string, number>;
+pendingScrollIndex: number | null;
+```
+
+Recommended defaults:
+
+```ts
+pageSize: 100,
+totalCount: 0,
+pageCache: new Map<number, Readonly<PlexMediaSlimDTO[]>>(),
+loadedPages: new Set<number>(),
+loadingPages: new Set<number>(),
+navigationIndexes: new Map<string, number>(),
+pendingScrollIndex: null,
+```
+
+- [ ] **Step 2: Keep old `items` temporarily**
+
+Do not remove `items` immediately. Keep it as a compatibility bridge until table/poster/components are migrated.
+
+- [ ] **Step 3: Add cache reset action**
+
+Add:
+
+```ts
+resetPagedCache() {
+  state.pageCache = new Map<number, Readonly<PlexMediaSlimDTO[]>>();
+  state.loadedPages = new Set<number>();
+  state.loadingPages = new Set<number>();
+  state.totalCount = 0;
+  state.navigationIndexes = new Map<string, number>();
+  state.scrollDict = new Map<string, number>();
+  state.pendingScrollIndex = null;
+}
+```
+
+Use direct state assignment in the store; this file already uses reactive state assignment.
+
+- [ ] **Step 4: Run frontend type/lint diagnostics through WebStorm MCP if available**
+
+Expected: no TypeScript errors in changed file.
+
+---
+
+## Task 7: Add page insertion and index lookup helpers
+
+**Files:**
+
+- Modify: `src/AppHost/ClientApp/src/store/mediaOverviewStore.ts`
+
+- [ ] **Step 1: Add helper to compute page for global index**
+
+```ts
+getPageForIndex(index: number): number {
+  return Math.max(0, Math.floor(index / state.pageSize));
+}
+```
+
+- [ ] **Step 2: Add helper to insert a page**
+
+```ts
+setPage(page: number, data: PlexMediaStatisticsDTO | null) {
+  if (!data) {
+    return;
+  }
+
+  state.pageCache.set(page, Object.freeze(data.mediaList));
+  state.loadedPages.add(page);
+  state.totalCount = data.totalCount;
+  state.itemsLength = data.totalCount;
+
+  state.allMovieCount = data.movieCount;
+  state.allTvShowCount = data.tvShowCount;
+  state.allSeasonCount = data.seasonCount;
+  state.allEpisodeCount = data.episodeCount;
+  state.allFileSize = data.mediaSize;
+}
+```
+
+- [ ] **Step 3: Add helper to read item by global index**
+
+```ts
+getItemByIndex(index: number): PlexMediaSlimDTO | null {
+  if (index < 0 || index >= state.totalCount) {
+    return null;
+  }
+
+  const page = actions.getPageForIndex(index);
+  const pageItems = state.pageCache.get(page);
+  if (!pageItems) {
+    return null;
+  }
+
+  return pageItems[index - page * state.pageSize] ?? null;
+}
+```
+
+- [ ] **Step 4: Add loaded-range helper**
+
+```ts
+isIndexLoaded(index: number): boolean {
+  return actions.getItemByIndex(index) !== null;
+}
+```
+
+- [ ] **Step 5: Run WebStorm diagnostics**
+
+Expected: no TypeScript errors.
+
+---
+
+## Task 8: Replace first load with first page load
+
+**Files:**
+
+- Modify: `src/AppHost/ClientApp/src/store/mediaOverviewStore.ts`
+
+- [ ] **Step 1: Add `requestMediaFirstPage`**
+
+```ts
+requestMediaFirstPage(): Observable<PlexMediaStatisticsDTO | null> {
+  if (state.loading) {
+    Log.debug('Initial media request already in progress, skipping');
+    return of(null);
+  }
+
+  actions.resetPagedCache();
+
+  const page = 0;
+  const size = state.pageSize;
+
+  state.loading = true;
+  Log.debug('Starting initial paged media request', {
+    libraryId: state.libraryId,
+    mediaType: get(getters.getMediaType),
+    page,
+    size,
+  });
+
+  return forkJoin([
+    actions.refreshMetaData(),
+    defer(() =>
+      state.libraryId > 0
+        ? libraryStore.refreshLibrary(state.libraryId)
+        : of(null),
+    ).pipe(takeUntil(cancelSubject$)),
+    defer(() =>
+      state.libraryId === 0
+        ? actions.refreshAllLibraryMediaByType(page, size)
+        : actions.refreshLibraryMedia(page, size),
+    ).pipe(
+      tap((data) => {
+        actions.setPage(page, data);
+      }),
+    ),
+  ]).pipe(
+    takeUntil(cancelSubject$),
+    map(([_, __, media]) => media),
+    tap({
+      next: () => {
+        state.loading = false;
+        Log.debug('Initial paged media request completed successfully');
+      },
+      error: (err) => {
+        state.loading = false;
+        Log.error('Initial paged media request failed', err);
+      },
+      complete: () => {
+        if (state.loading) {
+          state.loading = false;
+          Log.debug('Initial paged media request was cancelled');
+        }
+      },
+    }),
+  );
+}
+```
+
+- [ ] **Step 2: Make existing `requestMedia()` delegate to first page**
+
+Temporarily replace `requestMedia()` body with:
+
+```ts
+return actions.requestMediaFirstPage();
+```
+
+This preserves current callers.
+
+- [ ] **Step 3: Ensure metadata anchors are copied into store**
+
+When `refreshMetaData()` receives `result.value`, also set:
+
+```ts
+state.navigationIndexes = new Map(Object.entries(result.value.navigationIndexes ?? {}));
+state.scrollDict = new Map(Object.entries(result.value.navigationIndexes ?? {}));
+```
+
+Match exact generated casing. It should be `navigationIndexes` in TypeScript when generated from `NavigationIndexes`.
+
+- [ ] **Step 4: Run WebStorm diagnostics**
+
+Expected: no TypeScript errors.
+
+---
+
+## Task 9: Add page and range loading actions
+
+**Files:**
+
+- Modify: `src/AppHost/ClientApp/src/store/mediaOverviewStore.ts`
+
+- [ ] **Step 1: Add `requestMediaPage`**
+
+```ts
+requestMediaPage(page: number): Observable<PlexMediaStatisticsDTO | null> {
+  if (page < 0) {
+    return of(null);
+  }
+
+  if (state.loadedPages.has(page) || state.loadingPages.has(page)) {
+    return of(null);
+  }
+
+  state.loadingPages.add(page);
+
+  return defer(() =>
+    state.libraryId === 0
+      ? actions.refreshAllLibraryMediaByType(page, state.pageSize)
+      : actions.refreshLibraryMedia(page, state.pageSize),
+  ).pipe(
+    takeUntil(cancelSubject$),
+    tap((data) => actions.setPage(page, data)),
+    tap({
+      next: () => state.loadingPages.delete(page),
+      error: (err) => {
+        state.loadingPages.delete(page);
+        Log.error('Paged media request failed', { page, err });
+      },
+      complete: () => state.loadingPages.delete(page),
+    }),
+  );
+}
+```
+
+- [ ] **Step 2: Add `ensureRangeLoaded`**
+
+```ts
+ensureRangeLoaded(startIndex: number, endIndex: number): Observable<(PlexMediaStatisticsDTO | null)[]> {
+  if (state.totalCount <= 0) {
+    return of([]);
+  }
+
+  const safeStart = Math.max(0, startIndex);
+  const safeEnd = Math.min(state.totalCount - 1, endIndex);
+
+  if (safeEnd < safeStart) {
+    return of([]);
+  }
+
+  const startPage = actions.getPageForIndex(safeStart);
+  const endPage = actions.getPageForIndex(safeEnd);
+  const requests: Observable<PlexMediaStatisticsDTO | null>[] = [];
+
+  for (let page = startPage; page <= endPage; page++) {
+    if (!state.loadedPages.has(page) && !state.loadingPages.has(page)) {
+      requests.push(actions.requestMediaPage(page));
+    }
+  }
+
+  return requests.length ? forkJoin(requests) : of([]);
+}
+```
+
+- [ ] **Step 3: Add `prefetchAroundIndex`**
+
+```ts
+prefetchAroundIndex(index: number, radius: number = 50): Observable<(PlexMediaStatisticsDTO | null)[]> {
+  return actions.ensureRangeLoaded(index - radius, index + radius);
+}
+```
+
+- [ ] **Step 4: Run WebStorm diagnostics**
+
+Expected: no TypeScript errors.
+
+---
+
+# Phase 5: Frontend sort navigation wiring
+
+## Task 10: Keep `AlphabetNavigation.vue` simple but source global navigation indexes
+
+**Files:**
+
+- Modify: `src/AppHost/ClientApp/src/components/Navigation/AlphabetNavigation.vue`
+
+- [ ] **Step 1: Keep current template shape**
+
+The current template can remain conceptually the same:
+
+```vue
+<q-btn
+  v-for="[displayValue, scrollIndex] in mediaOverviewStore.scrollDict"
+  :key="displayValue"
+  class="navigation-btn"
+  :label="displayValue"
+  flat
+  square
+  no-wrap
+  :data-cy="`letter-${displayValue}-alphabet-navigation-btn`"
+  @click="sendMediaOverviewScrollToCommand(scrollIndex)" />
+```
+
+The important change is not here: `scrollDict` must now be populated from backend `navigationIndexes`, not local loaded items.
+
+- [ ] **Step 2: Hide when no anchors exist**
+
+Wrap root with:
+
+```vue
+<div
+  v-if="mediaOverviewStore.scrollDict.size > 0"
+  class="alphabet-navigation-container">
+```
+
+This hides sort navigation when the backend returns no navigation labels.
+
+- [ ] **Step 3: Run WebStorm diagnostics**
+
+Expected: no Vue/TypeScript errors.
+
+---
+
+## Task 11: Load target range before scroll highlight
+
+**Files:**
+
+- Modify: `src/AppHost/ClientApp/src/components/MediaOverview/MediaTable/MediaTable.vue`
+- Modify: `src/AppHost/ClientApp/src/components/MediaOverview/PosterTable/PosterTable.vue`
+
+- [ ] **Step 1: Update event listener in `MediaTable.vue`**
+
+Replace direct listener body:
+
+```ts
+listenMediaOverviewScrollToCommand((scrollIndex) => {
+  scrollToIndex(scrollIndex);
+});
+```
+
+with:
+
+```ts
+listenMediaOverviewScrollToCommand((scrollIndex) => {
+  useSubscription(
+    mediaOverviewStore.prefetchAroundIndex(scrollIndex, 50).pipe(
+      tap(() => scrollToIndex(scrollIndex)),
+    ).subscribe(),
+  );
+});
+```
+
+Add required imports:
+
+```ts
+import { tap } from 'rxjs';
+import { useSubscription } from '@vueuse/rxjs';
+```
+
+Respect existing Reaparr frontend standards: use `useSubscription`, not unmanaged subscriptions.
+
+- [ ] **Step 2: Update event listener in `PosterTable.vue` similarly**
+
+Replace direct scroll call with prefetch + scroll.
+
+- [ ] **Step 3: Handle bounds after global count migration**
+
+In `PosterTable.vue`, replace checks against `props.items.length` with `mediaOverviewStore.totalCount`.
+
+- [ ] **Step 4: Run WebStorm diagnostics**
+
+Expected: no Vue/TypeScript errors.
+
+---
+
+# Phase 6: Virtualizer count and placeholders
+
+## Task 12: Convert `MediaTable.vue` from loaded rows to global count
+
+**Files:**
+
+- Modify: `src/AppHost/ClientApp/src/components/MediaOverview/MediaTable/MediaTable.vue`
+
+- [ ] **Step 1: Change virtualizer count**
+
+Replace:
+
+```ts
+count: props.rows.length,
+```
+
+with:
+
+```ts
+count: mediaOverviewStore.totalCount,
+```
+
+- [ ] **Step 2: Read row by global index**
+
+In template, replace direct `rows[virtualRow.index]!` usage with a local helper:
+
+```ts
+function getRow(index: number): PlexMediaSlimDTO | null {
+  return mediaOverviewStore.getItemByIndex(index);
+}
+```
+
+- [ ] **Step 3: Render placeholder row when unloaded**
+
+In the virtual row body:
+
+```vue
+<MediaTableRow
+  v-if="getRow(virtualRow.index)"
+  :index="virtualRow.index"
+  :data-cy="`media-table-row-${virtualRow.index}`"
+  :columns="mediaTableColumns"
+  :row="getRow(virtualRow.index)!"
+  selectable
+  :selected="isSelected(getRow(virtualRow.index)!.id)"
+  :disable-highlight="disableHighlight"
+  :disable-hover-click="disableHoverClick"
+  @selected="updateSelectedRow(getRow(virtualRow.index)!.id, $event)" />
+<div
+  v-else
+  class="media-table-row-placeholder"
+  :data-cy="`media-table-row-placeholder-${virtualRow.index}`">
+  <q-skeleton type="text" />
+</div>
+```
+
+- [ ] **Step 4: Add placeholder style**
+
+```scss
+.media-table-row-placeholder {
+  height: $media-table-row-height;
+  display: flex;
+  align-items: center;
+  padding: 0 16px;
+}
+```
+
+- [ ] **Step 5: Trigger prefetch from virtualizer range**
+
+In `onChange`, inspect current virtual items and call `ensureRangeLoaded` around visible indexes. Debounce if needed.
+
+Conceptual code:
+
+```ts
+const virtualItems = _instance.getVirtualItems();
+const first = virtualItems[0]?.index;
+const last = virtualItems[virtualItems.length - 1]?.index;
+if (first !== undefined && last !== undefined) {
+  useSubscription(mediaOverviewStore.ensureRangeLoaded(first - 20, last + 20).subscribe());
+}
+```
+
+If `onChange` cannot safely call `useSubscription` repeatedly, move this to a watcher on `rowVirtualizer.getVirtualItems()` or a small debounced function.
+
+- [ ] **Step 6: Run WebStorm diagnostics**
+
+Expected: no Vue/TypeScript errors.
+
+---
+
+## Task 13: Convert `PosterTable.vue` from loaded items to global count
+
+**Files:**
+
+- Modify: `src/AppHost/ClientApp/src/components/MediaOverview/PosterTable/PosterTable.vue`
+
+- [ ] **Step 1: Change row count**
+
+Replace:
+
+```ts
+const rowCount = computed(() => Math.ceil(props.items.length / get(gridItems)));
+```
+
+with:
+
+```ts
+const rowCount = computed(() => Math.ceil(mediaOverviewStore.totalCount / get(gridItems)));
+```
+
+- [ ] **Step 2: Change row item lookup to sparse lookup**
+
+Replace `getRowItems` with logic that returns loaded item or placeholder metadata.
+
+Suggested local type:
+
+```ts
+type PosterGridItem = {
+  index: number;
+  item: PlexMediaSlimDTO | null;
+};
+```
+
+Suggested helper:
+
+```ts
+function getRowItems(rowIndex: number): PosterGridItem[] {
+  const cols = get(gridItems);
+  const result: PosterGridItem[] = [];
+
+  for (let col = 0; col < cols; col++) {
+    const index = rowIndex * cols + col;
+    if (index >= mediaOverviewStore.totalCount) {
+      break;
+    }
+
+    result.push({
+      index,
+      item: mediaOverviewStore.getItemByIndex(index),
+    });
+  }
+
+  return result;
+}
+```
+
+- [ ] **Step 3: Render poster placeholder**
+
+Template concept:
+
+```vue
+<template
+  v-for="entry in getRowItems(virtualRow.index)"
+  :key="entry.item?.id ?? `placeholder-${entry.index}`">
+  <MediaPoster
+    v-if="entry.item"
+    :media-item="entry.item"
+    :active="true"
+    :data-scroll-index="entry.index"
+    @download="sendMediaOverviewDownloadCommand($event)"
+    @open-media-details="onOpenMediaDetails" />
+  <div
+    v-else
+    class="poster-placeholder"
+    :data-scroll-index="entry.index">
+    <q-skeleton type="rect" />
+  </div>
+</template>
+```
+
+- [ ] **Step 4: Trigger range prefetch from visible virtual rows**
+
+Convert row range to flat item range:
+
+```ts
+const firstFlatIndex = firstRow * get(gridItems);
+const lastFlatIndex = ((lastRow + 1) * get(gridItems)) - 1;
+```
+
+Then call:
+
+```ts
+mediaOverviewStore.ensureRangeLoaded(firstFlatIndex - 50, lastFlatIndex + 50)
+```
+
+- [ ] **Step 5: Run WebStorm diagnostics**
+
+Expected: no Vue/TypeScript errors.
+
+---
+
+# Phase 7: Search/filter/sort invalidation
+
+## Task 14: Ensure every query context change resets paging
+
+**Files:**
+
+- Modify: `src/AppHost/ClientApp/src/store/mediaOverviewStore.ts`
+- Inspect/modify components that set search/filter/sort
+
+- [ ] **Step 1: Metadata filters already call `requestMedia()`**
+
+Existing methods like `setMetaData`, `unsetMetaData`, `changeAllMediaOverviewType`, and `onOptionsClosed` call `requestMedia()`. Since `requestMedia()` delegates to `requestMediaFirstPage()`, they should reset paging automatically.
+
+- [ ] **Step 2: Update sort behavior**
+
+Current `sortMedia` sorts client-side. For paged mode, sorting must become server-side. Update sort toggles to call `requestMediaFirstPage()` instead of sorting loaded items.
+
+Recommended transition:
+
+```ts
+toggleSortMedia(field: MediaSortField) {
+  if (state.sortedState.field === field) {
+    state.sortedState.sort = state.sortedState.sort === SortDirection.Asc ? SortDirection.Desc : SortDirection.Asc;
+  } else {
+    state.sortedState = { field, sort: SortDirection.Asc };
+  }
+
+  useSubscription(actions.requestMediaFirstPage().subscribe());
+}
+```
+
+- [ ] **Step 3: Update search behavior**
+
+Current `getMediaItems` filters locally using `filterQuery`. For paged mode, search should request first page from server. Locate search bar component and ensure query changes call `requestMediaFirstPage()` with debounce.
+
+- [ ] **Step 4: Run WebStorm diagnostics**
+
+Expected: no TypeScript errors.
+
+---
+
+# Phase 8: Selection behavior
+
+## Task 15: Make selection explicit-ID based for paged mode
+
+**Files:**
+
+- Modify: `src/AppHost/ClientApp/src/store/mediaOverviewStore.ts`
+- Modify: `src/AppHost/ClientApp/src/components/MediaOverview/MediaTable/MediaTable.vue` if needed
+
+- [ ] **Step 1: Keep row selection as explicit loaded IDs**
+
+Current per-row selection remains valid because it uses media IDs.
+
+- [ ] **Step 2: Adjust root select behavior**
+
+Current root select maps all `state.items`, which will no longer contain every item. For initial paged implementation, root select should only select loaded items or be disabled until query-wide selection is designed.
+
+Recommended initial behavior:
+
+```ts
+setRootSelected(value: boolean) {
+  const loadedIds = [...state.pageCache.values()]
+    .flatMap((items) => items.map((x) => x.id));
+
+  actions.setSelection({
+    indexKey: state.selection?.indexKey ?? 0,
+    keys: value ? loadedIds : [],
+    allSelected: false,
+  } as ISelection);
+}
+```
+
+- [ ] **Step 3: Avoid showing all-selected for unloaded total count**
+
+`isRootSelected` should compare selected IDs against loaded IDs, not `itemsLength`, unless query-wide select is later implemented.
+
+- [ ] **Step 4: Run WebStorm diagnostics**
+
+Expected: no TypeScript errors.
+
+---
+
+# Phase 9: Tests and verification
+
+## Task 16: Backend tests for total count and navigation indexes
+
+**Files:**
+
+- Test: Application unit/integration tests depending on existing endpoint test conventions
+
+- [ ] **Step 1: Add test data with titles**
+
+Use titles that cover buckets:
+
+```text
+# -> "1 Documentary"
+A -> "Alien"
+B -> "Blade Runner"
+M -> "Mad Max"
+Z -> "Zodiac"
+```
+
+- [ ] **Step 2: Assert returned navigation indexes**
+
+Expected example for ascending title order:
+
+```text
+# = 0
+A = 1
+B = 2
+M = 3
+Z = 4
+```
+
+- [ ] **Step 3: Assert filters affect navigation indexes**
+
+Apply a filter/search that removes `Alien`; assert `A` is absent. Also add at least one non-title sort navigation test, preferably `year`, because it is scalar and easy to assert.
+
+- [ ] **Step 4: Run targeted backend tests**
+
+Before running dotnet commands, check for THE FINALS process per Reaparr backend skill. Then run the smallest relevant test project.
+
+---
+
+## Task 17: Frontend store tests for sparse cache and query resets
+
+**Files:**
+
+- Test: frontend unit test location matching existing store test conventions
+
+- [ ] **Step 1: Test page insertion**
+
+Arrange page size 100, insert page 4, assert global index 400 resolves to first item on that page.
+
+- [ ] **Step 2: Test unloaded index returns null**
+
+Assert `getItemByIndex(999)` returns `null` when page is absent.
+
+- [ ] **Step 3: Test `ensureRangeLoaded` page calculation**
+
+For range `95..205` with page size 100, assert pages 0, 1, and 2 are requested.
+
+- [ ] **Step 4: Test navigation jump prefetch**
+
+Given `navigationIndexes = new Map([["M", 41234]])`, assert prefetch is called for around index 41234.
+
+- [ ] **Step 5: Test search/sort reset first page**
+
+Changing search or sort should clear the sparse cache and request page 0 with the active query params.
+
+- [ ] **Step 6: Run targeted frontend tests**
+
+Use the project’s existing Bun/Vitest script via MCP/WebStorm run tooling where available.
+
+---
+
+## Task 18: Manual QA checklist
+
+- [ ] Open a large movie or TV library.
+- [ ] Confirm first render does not request `size = 0`.
+- [ ] Confirm first render does not download all media.
+- [ ] Confirm virtualizer count uses active `totalCount`.
+- [ ] Scroll down slowly; placeholders should resolve into rows/posters.
+- [ ] Scroll quickly deep into the list; no blank permanent gaps.
+- [ ] Click a title label such as `M`; list jumps near M and fills around target.
+- [ ] Change sort to year; navigation labels change to years and jump correctly.
+- [ ] Change sort to quality; navigation labels change to quality labels if supported.
+- [ ] Search for a title; list, count, and navigation labels reset to the searched result set.
+- [ ] Change metadata filter; list, count, and navigation labels reset.
+- [ ] Select individual loaded rows; download button behavior remains correct.
+- [ ] Root select selects loaded rows only and does not claim query-wide selection.
+
+---
+
+# Risks and Follow-up Decisions
+
+## Risk 1: Accurate global index calculation
+
+Calculating first global index per label is hardest when labels are derived from non-trivial fields such as quality or date buckets. Prefer database-side ordering/counting where possible. If an initial implementation projects minimal scalar fields into memory to compute indexes, keep it isolated and add a follow-up optimization issue.
+
+## Risk 2: `MediaCount` semantics
+
+`MediaCount` currently means count of returned items in the DTO mapper. Virtualization must use explicit `TotalCount`. Do not reuse `MediaCount` as total matching count.
+
+## Risk 3: Client-side sorting/filtering must end for paged mode
+
+For 100k media, client-side sorting/filtering of loaded pages gives incorrect global order and incorrect navigation indexes. The final implementation must push sort/search/filter to the backend.
+
+## Risk 4: Query-wide selection
+
+Selecting all matching media across unloaded pages is a separate feature. Initial implementation should make root selection loaded-only or disable root select for paged mode.
+
+## Risk 5: Natural sort parity
+
+Existing all-media behavior uses natural sorting after fetching data, which is incompatible with correct deep paging. The first server-side implementation may use deterministic DB ordering by `SearchTitle`/`SortIndex`. Document any visible sort parity differences and add a follow-up if exact natural sorting is required.
+
+## Risk 6: Generated API workflow
+
+The frontend generated API must be updated from backend Swagger. If backend dev server or generation fails, stop and report rather than silently committing hand-edited generated files.
+
+---
+
+# Recommended commit sequence
+
+1. `feat(api): add active media total count to paged response`
+2. `feat(api): support media overview search and server sort query`
+3. `feat(api): add sort-aware media navigation indexes`
+4. `chore(frontend): regenerate media overview api contracts`
+5. `feat(frontend): add sparse media overview page cache`
+6. `feat(frontend): load media overview pages by visible range`
+7. `feat(frontend): support sort navigation jump prefetch`
+8. `feat(frontend): render placeholders for unloaded media rows`
+9. `test: cover media overview paging totals and navigation cache`
+
+---
+
+# Completion Criteria
+
+Implementation is complete only when:
+
+- Media overview no longer requests `size = 0` for normal browsing.
+- Paged media responses expose `totalCount` for the active query.
+- Virtualizer count is based on active `totalCount`.
+- Backend applies filters/search/sort before count and page.
+- All-media mode no longer sorts only inside an already-paged result.
+- Missing items render as placeholders.
+- Scrolling loads visible ranges without duplicate page requests.
+- Navigation buttons are based on backend-provided `label => global index` values.
+- Jumping to a navigation label fetches a local range around the target and scrolls there.
+- Metadata/filter/sort/search changes reset sparse cache and navigation labels.
+- Targeted backend and frontend tests pass.

--- a/src/AppHost/ClientApp/src/components/MediaOverview/MediaOverviewSearchBar.vue
+++ b/src/AppHost/ClientApp/src/components/MediaOverview/MediaOverviewSearchBar.vue
@@ -1,7 +1,8 @@
 <template>
 	<q-input
-		v-model="mediaOverviewStore.filterQuery"
+		:model-value="mediaOverviewStore.filterQuery"
 		:debounce="300"
+		@update:model-value="onFilterQueryChanged"
 		outlined
 		input-style="font-size: 1.25rem"
 		rounded>
@@ -29,6 +30,7 @@
 </template>
 
 <script setup lang="ts">
+import { useSubscription } from '@vueuse/rxjs';
 import { useMediaOverviewStore } from '@store';
 import IconButton from '@components/Buttons/IconButton.vue';
 import type { IMetaDataMediaFilter } from '@interfaces';
@@ -43,5 +45,10 @@ withDefaults(defineProps<{
 
 function unsetMetaData(key: keyof IMetaDataMediaFilter) {
 	useSubscription(mediaOverviewStore.unsetMetaData(key).subscribe());
+}
+
+function onFilterQueryChanged(value: string | number | null) {
+	mediaOverviewStore.setFilterQuery(String(value ?? ''));
+	useSubscription(mediaOverviewStore.requestMediaFirstPage().subscribe());
 }
 </script>

--- a/src/AppHost/ClientApp/src/components/MediaOverview/MediaTable/MediaTable.vue
+++ b/src/AppHost/ClientApp/src/components/MediaOverview/MediaTable/MediaTable.vue
@@ -48,6 +48,8 @@
 import Log from 'consola';
 import { useVirtualizer } from '@tanstack/vue-virtual';
 import { get, set } from '@vueuse/core';
+import { useSubscription } from '@vueuse/rxjs';
+import { tap } from 'rxjs';
 import type { PlexMediaSlimDTO } from '@dto';
 import type { ISelection } from '@interfaces';
 import {
@@ -91,11 +93,11 @@ const BROWSER_MAX_CSS_HEIGHT = 33_000_000;
 
 const rowVirtualizer = useVirtualizer(
 	computed(() => ({
-		count: props.rows.length,
+		count: mediaOverviewStore.totalCount,
 		getScrollElement: () => get(qTableRef),
 		estimateSize: () => ROW_HEIGHT,
 		overscan: 10,
-		getItemKey: (index: number) => props.rows[index]?.id ?? index,
+		getItemKey: (index: number) => mediaOverviewStore.getItemByIndex(index)?.id ?? index,
 		onChange: (_instance: unknown, sync: boolean) => {
 			// sync=false means TanStack has finished its scroll-triggered re-render
 			if (sync)

--- a/src/AppHost/ClientApp/src/components/Navigation/AlphabetNavigation.vue
+++ b/src/AppHost/ClientApp/src/components/Navigation/AlphabetNavigation.vue
@@ -1,5 +1,7 @@
 <template>
-	<div class="alphabet-navigation-container">
+	<div
+		v-if="mediaOverviewStore.scrollDict.size > 0"
+		class="alphabet-navigation-container">
 		<div class="alphabet-navigation">
 			<q-btn
 				v-for="[displayValue, scrollIndex] in mediaOverviewStore.scrollDict"

--- a/src/AppHost/ClientApp/src/store/mediaOverviewStore.ts
+++ b/src/AppHost/ClientApp/src/store/mediaOverviewStore.ts
@@ -1,6 +1,5 @@
 import Log from 'consola';
-import { cloneDeep, isNumber, orderBy, sortBy, uniqueId } from 'lodash-es';
-import { format } from 'date-fns';
+import { cloneDeep, isNumber, sortBy, uniqueId } from 'lodash-es';
 import { acceptHMRUpdate, defineStore } from 'pinia';
 import { computed, reactive, toRefs } from 'vue';
 import { get } from '@vueuse/core';
@@ -19,7 +18,7 @@ import { plexLibraryApi, plexMediaApi } from '@api';
 import { map, tap, takeUntil } from 'rxjs/operators';
 import { defer, forkJoin, type Observable, of, Subject } from 'rxjs';
 import { useLibraryStore, useSettingsStore } from '@store';
-import { getHighestQuality, getHighestQualityRank, getVideoQualityColor, translateVideoQuality } from '@composables';
+import { getVideoQualityColor, translateVideoQuality } from '@composables';
 import { useSubscription } from '@vueuse/rxjs';
 import { useI18n } from 'vue-i18n';
 
@@ -43,6 +42,13 @@ interface IMediaOverviewStoreState {
 	allFileSize: number;
 	metadata: IMetaDataMediaFilter;
 	metadataList: PlexMediaMetadataDTO;
+	pageSize: number;
+	totalCount: number;
+	pageCache: Map<number, Readonly<PlexMediaSlimDTO[]>>;
+	loadedPages: Set<number>;
+	loadingPages: Set<number>;
+	navigationIndexes: Map<string, number>;
+	pendingScrollIndex: number | null;
 }
 
 export const useMediaOverviewStore = defineStore(StoreNames.MediaOverviewStore, () => {
@@ -80,7 +86,15 @@ export const useMediaOverviewStore = defineStore(StoreNames.MediaOverviewStore, 
 			countries: [],
 			genres: [],
 			qualities: [],
+			navigationIndexes: {},
 		},
+		pageSize: 100,
+		totalCount: 0,
+		pageCache: new Map<number, Readonly<PlexMediaSlimDTO[]>>(),
+		loadedPages: new Set<number>(),
+		loadingPages: new Set<number>(),
+		navigationIndexes: new Map<string, number>(),
+		pendingScrollIndex: null,
 	};
 
 	const state = reactive<IMediaOverviewStoreState>(cloneDeep(defaultState));
@@ -97,28 +111,78 @@ export const useMediaOverviewStore = defineStore(StoreNames.MediaOverviewStore, 
 			state.loading = false;
 		},
 		initializeLibrary(libraryId: number): Observable<PlexMediaStatisticsDTO | null> {
-			// Cancel any in-flight requests first
 			actions.cancelPendingRequests();
-
-			// Update state
 			state.libraryId = libraryId;
 			state.isDetailView = false;
-
-			Log.debug('Initializing library', { libraryId, mediaType: get(getters.getMediaType) });
-
-			// Clear filters and sorting
 			actions.clearMetaDataFilter();
 			actions.clearSort();
-
-			// Load data for the library
 			return actions.requestMedia();
 		},
+		getPageForIndex(index: number): number {
+			return Math.max(0, Math.floor(index / state.pageSize));
+		},
+		resetPagedCache() {
+			state.pageCache = new Map<number, Readonly<PlexMediaSlimDTO[]>>();
+			state.loadedPages = new Set<number>();
+			state.loadingPages = new Set<number>();
+			state.totalCount = 0;
+			state.navigationIndexes = new Map<string, number>();
+			state.scrollDict = new Map<string, number>();
+			state.pendingScrollIndex = null;
+		},
+		setPage(page: number, data: PlexMediaStatisticsDTO | null) {
+			if (!data) {
+				return;
+			}
+
+			state.pageCache.set(page, Object.freeze(data.mediaList));
+			state.loadedPages.add(page);
+			state.totalCount = data.totalCount;
+			state.itemsLength = data.totalCount;
+
+			state.allMovieCount = data.movieCount;
+			state.allTvShowCount = data.tvShowCount;
+			state.allSeasonCount = data.seasonCount;
+			state.allEpisodeCount = data.episodeCount;
+			state.allFileSize = data.mediaSize;
+
+			const pages = [...state.pageCache.keys()].sort((a, b) => a - b);
+			const items = pages.flatMap((key) => state.pageCache.get(key) ?? []);
+			state.items = Object.freeze(items);
+			state.sortedItems = Object.freeze(items);
+		},
+		getItemByIndex(index: number): PlexMediaSlimDTO | null {
+			if (index < 0 || index >= state.totalCount) {
+				return null;
+			}
+
+			const page = actions.getPageForIndex(index);
+			const pageItems = state.pageCache.get(page);
+			if (!pageItems) {
+				return null;
+			}
+
+			return pageItems[index - page * state.pageSize] ?? null;
+		},
+		isIndexLoaded(index: number): boolean {
+			return actions.getItemByIndex(index) !== null;
+		},
 		refreshMetaData() {
-			return plexLibraryApi.getLibraryMediaMetadata(state.libraryId, { mediaType: get(getters.getMediaType) }).pipe(
+			return plexLibraryApi.getLibraryMediaMetadata(state.libraryId, {
+				mediaType: get(getters.getMediaType),
+				search: state.filterQuery,
+				sortField: state.sortedState.field,
+				sortDirection: state.sortedState.sort,
+				filterOwnedMedia: settingsStore.generalSettings.hideMediaFromOwnedServers,
+				filterOfflineMedia: settingsStore.generalSettings.hideMediaFromOfflineServers,
+				...state.metadata,
+			}).pipe(
 				takeUntil(cancelSubject$),
 				tap((result) => {
 					if (result.isSuccess && result.value) {
-						return state.metadataList = result.value;
+						state.metadataList = result.value;
+						state.navigationIndexes = new Map(Object.entries(result.value.navigationIndexes ?? {}));
+						state.scrollDict = new Map(Object.entries(result.value.navigationIndexes ?? {}));
 					}
 				}),
 			);
@@ -128,63 +192,50 @@ export const useMediaOverviewStore = defineStore(StoreNames.MediaOverviewStore, 
 				mediaType: get(getters.getMediaType),
 				page,
 				size,
+				search: state.filterQuery,
+				sortField: state.sortedState.field,
+				sortDirection: state.sortedState.sort,
 				filterOwnedMedia: settingsStore.generalSettings.hideMediaFromOwnedServers,
 				filterOfflineMedia: settingsStore.generalSettings.hideMediaFromOfflineServers,
 				...state.metadata,
 			}).pipe(
 				takeUntil(cancelSubject$),
-				map(({ isSuccess, value }): PlexMediaStatisticsDTO | null => {
-					if (isSuccess && value) {
-						return value;
-					}
-					return null;
-				}),
+				map(({ isSuccess, value }): PlexMediaStatisticsDTO | null => (isSuccess && value) ? value : null),
 			);
 		},
 		refreshLibraryMedia(page: number = 0, size: number = 100): Observable<PlexMediaStatisticsDTO | null> {
 			return plexLibraryApi.getPlexLibraryMediaEndpoint(state.libraryId, {
 				page,
 				size,
-				filterOfflineMedia: false,
-				filterOwnedMedia: false,
+				search: state.filterQuery,
+				sortField: state.sortedState.field,
+				sortDirection: state.sortedState.sort,
+				filterOwnedMedia: settingsStore.generalSettings.hideMediaFromOwnedServers,
+				filterOfflineMedia: settingsStore.generalSettings.hideMediaFromOfflineServers,
 				...state.metadata,
 			}).pipe(
 				takeUntil(cancelSubject$),
-				map(({ isSuccess, value }): PlexMediaStatisticsDTO | null => {
-					if (isSuccess && value) {
-						return value;
-					}
-					return null;
-				}),
+				map(({ isSuccess, value }): PlexMediaStatisticsDTO | null => (isSuccess && value) ? value : null),
 			);
 		},
-		requestMedia(): Observable<PlexMediaStatisticsDTO | null> {
+		requestMediaFirstPage(): Observable<PlexMediaStatisticsDTO | null> {
 			if (state.loading) {
-				Log.debug('Request already in progress, skipping');
 				return of(null);
 			}
 
+			actions.resetPagedCache();
+
 			const page = 0;
-			const size = 0;
+			const size = state.pageSize;
 
 			state.loading = true;
-			Log.debug('Starting media request', { libraryId: state.libraryId, mediaType: get(getters.getMediaType) });
 
 			return forkJoin([
 				actions.refreshMetaData(),
-				defer(() =>
-					state.libraryId > 0
-						? libraryStore.refreshLibrary(state.libraryId)
-						: of(null),
-				).pipe(takeUntil(cancelSubject$)),
-				defer(() =>
-					state.libraryId === 0
-						? actions.refreshAllLibraryMediaByType(page, size)
-						: actions.refreshLibraryMedia(page, size),
-				).pipe(
+				defer(() => state.libraryId > 0 ? libraryStore.refreshLibrary(state.libraryId) : of(null)).pipe(takeUntil(cancelSubject$)),
+				defer(() => state.libraryId === 0 ? actions.refreshAllLibraryMediaByType(page, size) : actions.refreshLibraryMedia(page, size)).pipe(
 					tap((data) => {
-						actions.setMedia(data);
-						actions.sortMedia(state.sortedState);
+						actions.setPage(page, data);
 					}),
 				),
 			]).pipe(
@@ -193,43 +244,74 @@ export const useMediaOverviewStore = defineStore(StoreNames.MediaOverviewStore, 
 				tap({
 					next: () => {
 						state.loading = false;
-						Log.debug('Media request completed successfully');
 					},
 					error: (err) => {
 						state.loading = false;
-						Log.error('Media request failed', err);
+						Log.error('Initial paged media request failed', err);
 					},
 					complete: () => {
-						// Handle cancellation
-						if (state.loading) {
-							state.loading = false;
-							Log.debug('Media request was cancelled');
-						}
+						state.loading = false;
 					},
 				}),
 			);
 		},
-		setMedia(data: PlexMediaStatisticsDTO | null) {
-			if (data) {
-				state.items = Object.freeze(data.mediaList);
-				state.itemsLength = data.mediaCount;
-
-				state.allMovieCount = data.movieCount;
-				state.allTvShowCount = data.tvShowCount;
-				state.allSeasonCount = data.seasonCount;
-				state.allEpisodeCount = data.episodeCount;
-				state.allFileSize = data.mediaSize;
-			} else {
-				state.items = Object.freeze([]);
-				state.itemsLength = 0;
-
-				state.allMovieCount = 0;
-				state.allTvShowCount = 0;
-				state.allSeasonCount = 0;
-				state.allEpisodeCount = 0;
-				state.allFileSize = 0;
+		requestMedia(): Observable<PlexMediaStatisticsDTO | null> {
+			return actions.requestMediaFirstPage();
+		},
+		requestMediaPage(page: number): Observable<PlexMediaStatisticsDTO | null> {
+			if (page < 0) {
+				return of(null);
 			}
-			state.filterQuery = '';
+
+			if (state.loadedPages.has(page) || state.loadingPages.has(page)) {
+				return of(null);
+			}
+
+			state.loadingPages.add(page);
+
+			return defer(() =>
+				state.libraryId === 0
+					? actions.refreshAllLibraryMediaByType(page, state.pageSize)
+					: actions.refreshLibraryMedia(page, state.pageSize),
+			).pipe(
+				takeUntil(cancelSubject$),
+				tap((data) => actions.setPage(page, data)),
+				tap({
+					next: () => state.loadingPages.delete(page),
+					error: (err) => {
+						state.loadingPages.delete(page);
+						Log.error('Paged media request failed', { page, err });
+					},
+					complete: () => state.loadingPages.delete(page),
+				}),
+			);
+		},
+		ensureRangeLoaded(startIndex: number, endIndex: number): Observable<(PlexMediaStatisticsDTO | null)[]> {
+			if (state.totalCount <= 0) {
+				return of([]);
+			}
+
+			const safeStart = Math.max(0, startIndex);
+			const safeEnd = Math.min(state.totalCount - 1, endIndex);
+
+			if (safeEnd < safeStart) {
+				return of([]);
+			}
+
+			const startPage = actions.getPageForIndex(safeStart);
+			const endPage = actions.getPageForIndex(safeEnd);
+			const requests: Observable<PlexMediaStatisticsDTO | null>[] = [];
+
+			for (let page = startPage; page <= endPage; page++) {
+				if (!state.loadedPages.has(page) && !state.loadingPages.has(page)) {
+					requests.push(actions.requestMediaPage(page));
+				}
+			}
+
+			return requests.length ? forkJoin(requests) : of([]);
+		},
+		prefetchAroundIndex(index: number, radius: number = 50): Observable<(PlexMediaStatisticsDTO | null)[]> {
+			return actions.ensureRangeLoaded(index - radius, index + radius);
 		},
 		setMetaData({
 			countryId,
@@ -253,7 +335,7 @@ export const useMediaOverviewStore = defineStore(StoreNames.MediaOverviewStore, 
 				state.metadata.quality = quality;
 			}
 
-			return actions.requestMedia();
+			return actions.requestMediaFirstPage();
 		},
 		unsetMetaData(key: keyof IMetaDataMediaFilter): Observable<PlexMediaStatisticsDTO | null> {
 			switch (key) {
@@ -267,7 +349,7 @@ export const useMediaOverviewStore = defineStore(StoreNames.MediaOverviewStore, 
 					break;
 			}
 
-			return actions.requestMedia();
+			return actions.requestMediaFirstPage();
 		},
 		clearMetaDataFilter() {
 			state.metadata = {
@@ -279,85 +361,11 @@ export const useMediaOverviewStore = defineStore(StoreNames.MediaOverviewStore, 
 		},
 		changeAllMediaOverviewType(mediaType: PlexMediaType) {
 			settingsStore.displaySettings.allOverviewViewMode = mediaType;
-			useSubscription(actions.requestMedia().subscribe());
+			useSubscription(actions.requestMediaFirstPage().subscribe());
 		},
 		// This function calculates the scroll navigation options based on the current media items and active sorting.
 		setMediaIndexNavigationOptions() {
-			// These media items are already correctly sorted based on the active sort, so we can use them to determine the index positions for each key
-			const items = get(getters.getMediaItems);
-			const activeSort = get(getters.getActiveSort);
-			const field = activeSort.field;
-
-			// GB = 1,000,000,000 bytes (not 1,073,741,824) to align with Plex's media size formatting which uses decimal units
-			const GB = 1_000_000_000;
-
-			const keySelector: (item: PlexMediaSlimDTO) => string | null = (() => {
-				switch (field) {
-					case MediaSortField.Title:
-						return (it) => {
-							const first = it.title?.trim().charAt(0) ?? '';
-							return /^[A-Za-z]$/.test(first) ? first.toUpperCase() : '#';
-						};
-					case MediaSortField.Year:
-						return (it) => String(it.year ?? '#');
-
-					case MediaSortField.Quality:
-						return (it) => translateVideoQuality(getHighestQuality(it));
-
-					case MediaSortField.Duration:
-						return (it) => {
-							const seconds = it.duration ?? 0;
-							const start = Math.floor(seconds / 600) * 10; // 10-min buckets
-							return `${start}–${start + 10} min`;
-						};
-
-					case MediaSortField.AddedAt:
-						return (it) => {
-							const raw = it.addedAt;
-							return raw ? format(new Date(raw), 'MMM yyyy') : null;
-						};
-
-					case MediaSortField.UpdatedAt:
-						return (it) => {
-							const raw = it.updatedAt;
-							return raw ? format(new Date(raw), 'MMM yyyy') : null;
-						};
-
-					case MediaSortField.MediaSize:
-						return (it) => {
-							const bytes = it.mediaSize ?? 0;
-							const start = Math.floor(bytes / GB);
-							return `${start}–${start + 1} GB`;
-						};
-
-					default:
-						return (it) => {
-							const first = (it.title ?? '').trim().charAt(0).toUpperCase();
-							return /^[A-Z]$/.test(first) ? first : '#';
-						};
-				}
-			})();
-
-			// Items are already sorted — iterating in order naturally yields keys in the correct sequence
-			const indexByKey = new Map<string, number>();
-			for (let i = 0; i < items.length; i++) {
-				const key = keySelector(items[i]!);
-				if (key == null)
-					continue; // skip items without a usable key (e.g. no date)
-				if (!indexByKey.has(key))
-					indexByKey.set(key, i);
-			}
-
-			const sortedKeys = (() => {
-				const keys = [...indexByKey.keys()];
-				if (field !== MediaSortField.Title) return keys;
-				const hash = keys.includes('#') ? ['#'] : [];
-				const letters = keys.filter((k) => k !== '#').sort((a, b) => a.localeCompare(b));
-				if (activeSort.sort === SortDirection.Desc) letters.reverse();
-				return [...hash, ...letters];
-			})();
-
-			state.scrollDict = new Map(sortedKeys.map((k) => [k, indexByKey.get(k)!]));
+			state.scrollDict = new Map(state.navigationIndexes);
 		},
 		setSelection(selection: ISelection) {
 			state.selection = selection;
@@ -375,10 +383,13 @@ export const useMediaOverviewStore = defineStore(StoreNames.MediaOverviewStore, 
 			} as ISelection);
 		},
 		setRootSelected(value: boolean) {
+			const loadedIds = [...state.pageCache.values()]
+				.flatMap((items) => items.map((x) => x.id));
+
 			actions.setSelection({
 				indexKey: state.selection?.indexKey ?? 0,
-				keys: value ? state.items.map((x) => x.id) : [],
-				allSelected: value,
+				keys: value ? loadedIds : [],
+				allSelected: false,
 			} as ISelection);
 		},
 		clearSort() {
@@ -387,6 +398,10 @@ export const useMediaOverviewStore = defineStore(StoreNames.MediaOverviewStore, 
 		},
 		clearFilter() {
 			state.filterQuery = '';
+			useSubscription(actions.requestMediaFirstPage().subscribe());
+		},
+		setFilterQuery(value: string) {
+			state.filterQuery = value;
 		},
 		toggleSortMedia(field: MediaSortField) {
 			if (state.sortedState.field === field) {
@@ -395,29 +410,11 @@ export const useMediaOverviewStore = defineStore(StoreNames.MediaOverviewStore, 
 				state.sortedState = { field, sort: SortDirection.Asc };
 			}
 
-			actions.sortMedia(state.sortedState);
+			useSubscription(actions.requestMediaFirstPage().subscribe());
 		},
 		sortMedia(event: IMediaOverviewSort) {
-			Log.debug('Sorting media with event', event);
-
-			if (event.sort === SortDirection.NoSort) {
-				state.sortedItems = [];
-				state.sortedState = event;
-				return;
-			}
-
-			const order = event.sort === SortDirection.Asc ? 'asc' : 'desc';
-
-			// Quality is not a direct field on PlexMediaSlimDTO; sort by derived rank
-			if (event.field === MediaSortField.Quality) {
-				state.sortedItems = Object.freeze(orderBy(state.items, [(item) => getHighestQualityRank(item)], [order]));
-			} else {
-				state.sortedItems = Object.freeze(orderBy(state.items, [event.field as keyof PlexMediaSlimDTO], [order]));
-			}
-
 			state.sortedState = event;
-
-			actions.setMediaIndexNavigationOptions();
+			useSubscription(actions.requestMediaFirstPage().subscribe());
 		},
 		$reset() {
 			Object.assign(state, cloneDeep(defaultState));
@@ -430,29 +427,15 @@ export const useMediaOverviewStore = defineStore(StoreNames.MediaOverviewStore, 
 		}),
 
 		hasNoSearchResults: computed((): boolean => {
-			return state.filterQuery != '' && get(getters.getMediaItems).length === 0;
+			return state.filterQuery !== '' && state.totalCount === 0;
 		}),
 		hasNoFilterResults: computed((): boolean => {
-			return state.metadataList.mediaCount > 0 && get(getters.getMediaItems).length === 0;
+			return state.metadataList.mediaCount > 0 && state.totalCount === 0;
 		}),
 		allMediaMode: computed(() => state.libraryId === 0),
 		library: computed(() => libraryStore.getLibrary(state.libraryId)),
 		getMediaItems: computed((): Readonly<PlexMediaSlimDTO[]> => {
-			if (!state.items) {
-				return [];
-			}
-			const query = state.filterQuery.toLowerCase();
-			if (get(getters.getIsSorted)) {
-				if (state.filterQuery != '') {
-					return state.sortedItems.filter((x) => x.searchTitle.includes(query));
-				}
-				return state.sortedItems;
-			} else {
-				if (state.filterQuery != '') {
-					return state.items.filter((x) => x.searchTitle.includes(query));
-				}
-				return state.items;
-			}
+			return state.items;
 		}),
 		getMediaViewMode: computed((): ViewMode => {
 			switch (get(getters.getMediaType)) {
@@ -471,7 +454,8 @@ export const useMediaOverviewStore = defineStore(StoreNames.MediaOverviewStore, 
 			return state.downloadButtonVisible || (get(getters.hasSelectedMedia) && get(getters.getMediaViewMode) === ViewMode.Table);
 		}),
 		isRootSelected: computed((): boolean | null => {
-			if (state.selection?.keys.length === state.itemsLength) {
+			const loadedIds = [...state.pageCache.values()].flatMap((items) => items.map((x) => x.id));
+			if (loadedIds.length > 0 && state.selection?.keys.length === loadedIds.length) {
 				return true;
 			}
 

--- a/src/AppHost/ClientApp/src/types/api/generated/PlexLibrary.ts
+++ b/src/AppHost/ClientApp/src/types/api/generated/PlexLibrary.ts
@@ -116,11 +116,17 @@ export class PlexLibrary {
        * @default 0
        */
       roleId: number;
+      /** @default "" */
+      search: string;
       /**
        * @format int32
        * @default 0
        */
       size: number;
+      /** @default "asc" */
+      sortDirection: string;
+      /** @default "sortIndex" */
+      sortField: string;
     },
     params: RequestParams = {},
   ) =>
@@ -143,8 +149,35 @@ export class PlexLibrary {
   getLibraryMediaMetadata = (
     plexLibraryId: number,
     query: {
+      /**
+       * @format int32
+       * @default 0
+       */
+      countryId: number;
+      /** @default false */
+      filterOfflineMedia: boolean;
+      /** @default false */
+      filterOwnedMedia: boolean;
+      /**
+       * @format int32
+       * @default 0
+       */
+      genreId: number;
       /** @default 0 */
       mediaType: PlexMediaType;
+      /** @default -1 */
+      quality: VideoQuality;
+      /**
+       * @format int32
+       * @default 0
+       */
+      roleId: number;
+      /** @default "" */
+      search: string;
+      /** @default "asc" */
+      sortDirection: string;
+      /** @default "sortIndex" */
+      sortField: string;
     },
     params: RequestParams = {},
   ) =>
@@ -254,11 +287,17 @@ export class PlexLibraryPaths {
        * @default 0
        */
       roleId: number;
+      /** @default "" */
+      search: string;
       /**
        * @format int32
        * @default 0
        */
       size: number;
+      /** @default "asc" */
+      sortDirection: string;
+      /** @default "sortIndex" */
+      sortField: string;
     },
   ) =>
     queryString.stringifyUrl({
@@ -269,8 +308,35 @@ export class PlexLibraryPaths {
   static getLibraryMediaMetadata = (
     plexLibraryId: number,
     query: {
+      /**
+       * @format int32
+       * @default 0
+       */
+      countryId: number;
+      /** @default false */
+      filterOfflineMedia: boolean;
+      /** @default false */
+      filterOwnedMedia: boolean;
+      /**
+       * @format int32
+       * @default 0
+       */
+      genreId: number;
       /** @default 0 */
       mediaType: PlexMediaType;
+      /** @default -1 */
+      quality: VideoQuality;
+      /**
+       * @format int32
+       * @default 0
+       */
+      roleId: number;
+      /** @default "" */
+      search: string;
+      /** @default "asc" */
+      sortDirection: string;
+      /** @default "sortIndex" */
+      sortField: string;
     },
   ) =>
     queryString.stringifyUrl({

--- a/src/AppHost/ClientApp/src/types/api/generated/PlexMedia.ts
+++ b/src/AppHost/ClientApp/src/types/api/generated/PlexMedia.ts
@@ -60,11 +60,17 @@ export class PlexMedia {
        * @default 0
        */
       roleId: number;
+      /** @default "" */
+      search: string;
       /**
        * @format int32
        * @default 0
        */
       size: number;
+      /** @default "asc" */
+      sortDirection: string;
+      /** @default "sortIndex" */
+      sortField: string;
     },
     params: RequestParams = {},
   ) =>
@@ -199,11 +205,17 @@ export class PlexMediaPaths {
      * @default 0
      */
     roleId: number;
+    /** @default "" */
+    search: string;
     /**
      * @format int32
      * @default 0
      */
     size: number;
+    /** @default "asc" */
+    sortDirection: string;
+    /** @default "sortIndex" */
+    sortField: string;
   }) => queryString.stringifyUrl({ url: `/api/PlexMedia`, query });
 
   static getMediaDetailByIdEndpoint = (

--- a/src/AppHost/ClientApp/src/types/api/generated/PlexServer.ts
+++ b/src/AppHost/ClientApp/src/types/api/generated/PlexServer.ts
@@ -182,11 +182,11 @@ export class PlexServer {
   /**
    * No description
    * * @tags Plexserver
-   * @name SetServerEnabledRequestEndpoint
+   * @name SetServerEnabledEndpoint
    * @request PUT:/api/PlexServer/{PlexServerId}/set-server-enabled
    * @secure
    */
-  setServerEnabledRequestEndpoint = (
+  setServerEnabledEndpoint = (
     plexServerId: number,
     data: SetServerEnabledRequest,
     params: RequestParams = {},
@@ -288,7 +288,7 @@ export class PlexServerPaths {
       query,
     });
 
-  static setServerEnabledRequestEndpoint = (plexServerId: number) =>
+  static setServerEnabledEndpoint = (plexServerId: number) =>
     queryString.stringifyUrl({
       url: `/api/PlexServer/${plexServerId}/set-server-enabled`,
     });

--- a/src/AppHost/ClientApp/src/types/api/generated/data-contracts.ts
+++ b/src/AppHost/ClientApp/src/types/api/generated/data-contracts.ts
@@ -829,6 +829,7 @@ export interface PlexMediaMetadataDTO {
   genres: PlexGenreDTO[];
   /** @format int32 */
   mediaCount: number;
+  navigationIndexes: Record<string, number>;
   qualities: PlexQualityDTO[];
   /** @format int32 */
   qualityCount: number;
@@ -892,6 +893,8 @@ export interface PlexMediaStatisticsDTO {
   movieCount: number;
   /** @format int32 */
   seasonCount: number;
+  /** @format int32 */
+  totalCount: number;
   /** @format int32 */
   tvShowCount: number;
 }
@@ -993,7 +996,6 @@ export interface PlexServerSettingItemModule {
   allowStreamDownloader: boolean;
   /** @format int32 */
   downloadSpeedLimit: number;
-  hidden: boolean;
   machineIdentifier: string;
   plexServerName: string;
 }

--- a/src/Application.Contracts/_Shared/Mappings/PlexMedia/DTO/PlexMediaMetadataDTO.cs
+++ b/src/Application.Contracts/_Shared/Mappings/PlexMedia/DTO/PlexMediaMetadataDTO.cs
@@ -46,4 +46,9 @@ public record PlexMediaMetadataDTO
     /// Gets or sets the list of distinct quality levels available in the media items of the <see cref="PlexLibrary"/>.
     /// </summary>
     public required List<PlexQualityDTO> Qualities { get; init; }
+
+    /// <summary>
+    /// Gets sort-aware navigation labels mapped to their first global index in the active filtered/searched/sorted result set.
+    /// </summary>
+    public Dictionary<string, int> NavigationIndexes { get; init; } = [];
 }

--- a/src/Application.Contracts/_Shared/Mappings/PlexMedia/DTO/PlexMediaStatisticsDTO.cs
+++ b/src/Application.Contracts/_Shared/Mappings/PlexMedia/DTO/PlexMediaStatisticsDTO.cs
@@ -2,6 +2,15 @@ namespace Reaparr.Application.Contracts;
 
 public class PlexMediaStatisticsDTO
 {
+    /// <summary>
+    /// Gets or sets the total number of media items matching the active query before paging.
+    /// This value is used by the frontend virtualizer.
+    /// </summary>
+    public required int TotalCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the count of media items in this returned page/list.
+    /// </summary>
     public required int MediaCount { get; set; }
 
     public required int MovieCount { get; set; }

--- a/src/Application.Contracts/_Shared/Mappings/PlexMedia/PlexMediaSlimDTOMapper.cs
+++ b/src/Application.Contracts/_Shared/Mappings/PlexMedia/PlexMediaSlimDTOMapper.cs
@@ -126,10 +126,11 @@ public static class PlexMediaSlimDTOMapper
 
     #endregion
 
-    public static PlexMediaStatisticsDTO ToStatisticsDTO(this List<PlexMediaSlimDTO> source)
+    public static PlexMediaStatisticsDTO ToStatisticsDTO(this List<PlexMediaSlimDTO> source, int? totalCount = null)
     {
         var stats = new PlexMediaStatisticsDTO
         {
+            TotalCount = totalCount ?? source.Count,
             MovieCount = 0,
             TvShowCount = 0,
             SeasonCount = 0,

--- a/src/Application/PlexLibraries/GetMedia/GetPlexLibraryMediaEndpoint.cs
+++ b/src/Application/PlexLibraries/GetMedia/GetPlexLibraryMediaEndpoint.cs
@@ -12,6 +12,8 @@ public class GetPlexLibraryMediaEndpointRequestValidator : Validator<GetPlexLibr
         RuleFor(x => x.PlexLibraryId).GreaterThan(0);
         RuleFor(x => x.Page).GreaterThanOrEqualTo(0);
         RuleFor(x => x.Size).GreaterThanOrEqualTo(0);
+        RuleFor(x => x.SortDirection).Must(x => x is "asc" or "desc");
+        RuleFor(x => x.SortField).Must(x => x is "sortIndex" or "year" or "addedAt" or "updatedAt" or "duration" or "mediaSize" or "quality");
     }
 }
 
@@ -83,6 +85,9 @@ public class GetPlexLibraryMediaEndpoint : BaseEndpoint<GetPlexLibraryMediaEndpo
                 ActorId = req.ActorId,
                 GenreId = req.GenreId,
                 Quality = req.Quality,
+                Search = req.Search,
+                SortField = req.SortField,
+                SortDirection = req.SortDirection,
             },
             ct: ct
         );
@@ -93,6 +98,6 @@ public class GetPlexLibraryMediaEndpoint : BaseEndpoint<GetPlexLibraryMediaEndpo
             return;
         }
 
-        await SendFluentResult(Result.Ok(mediaListResult.Value.ToStatisticsDTO()), ct);
+        await SendFluentResult(Result.Ok(mediaListResult.Value.Items.ToStatisticsDTO(mediaListResult.Value.TotalCount)), ct);
     }
 }

--- a/src/Application/PlexLibraries/GetMetadata/GetLibraryMediaMetadata.cs
+++ b/src/Application/PlexLibraries/GetMetadata/GetLibraryMediaMetadata.cs
@@ -7,6 +7,42 @@ public record GetLibraryMediaMetadataRequest
     [QueryParam, BindFrom("mediaType")]
     [DefaultValue(PlexMediaType.None)]
     public PlexMediaType MediaType { get; init; }
+
+    [QueryParam, BindFrom("countryId")]
+    [DefaultValue(0)]
+    public int CountryId { get; init; }
+
+    [QueryParam, BindFrom("genreId")]
+    [DefaultValue(0)]
+    public int GenreId { get; init; }
+
+    [QueryParam, BindFrom("roleId")]
+    [DefaultValue(0)]
+    public int ActorId { get; init; }
+
+    [QueryParam, BindFrom("quality")]
+    [DefaultValue(VideoQuality.None)]
+    public VideoQuality Quality { get; init; }
+
+    [QueryParam, BindFrom("filterOfflineMedia")]
+    [DefaultValue(false)]
+    public bool FilterOfflineMedia { get; init; }
+
+    [QueryParam, BindFrom("filterOwnedMedia")]
+    [DefaultValue(false)]
+    public bool FilterOwnedMedia { get; init; }
+
+    [QueryParam, BindFrom("search")]
+    [DefaultValue("")]
+    public string Search { get; init; } = string.Empty;
+
+    [QueryParam, BindFrom("sortField")]
+    [DefaultValue("sortIndex")]
+    public string SortField { get; init; } = "sortIndex";
+
+    [QueryParam, BindFrom("sortDirection")]
+    [DefaultValue("asc")]
+    public string SortDirection { get; init; } = "asc";
 }
 
 public class GetLibraryMediaMetadataRequestValidator : Validator<GetLibraryMediaMetadataRequest>
@@ -17,11 +53,16 @@ public class GetLibraryMediaMetadataRequestValidator : Validator<GetLibraryMedia
             .NotEqual(PlexMediaType.None)
             .When(x => x.PlexLibraryId == 0)
             .WithMessage("MediaType must not be 'None' when PlexLibraryId is 0.");
+
+        RuleFor(x => x.SortDirection).Must(x => x is "asc" or "desc");
+        RuleFor(x => x.SortField).Must(x => x is "sortIndex" or "year" or "addedAt" or "updatedAt" or "duration" or "mediaSize" or "quality");
     }
 }
 
 public class GetLibraryMediaMetadata : BaseEndpoint<GetLibraryMediaMetadataRequest, PlexMediaMetadataDTO>
 {
+    private const long Gigabyte = 1_000_000_000;
+
     private readonly ILogger _log;
     private readonly IReaparrDbContext _dbContext;
 
@@ -45,9 +86,9 @@ public class GetLibraryMediaMetadata : BaseEndpoint<GetLibraryMediaMetadataReque
     public override async Task HandleAsync(GetLibraryMediaMetadataRequest req, CancellationToken ct)
     {
         _log.Here().DebugApiCall(HttpContext, req);
+
         if (req.PlexLibraryId > 0)
         {
-            // First, verify the library exists
             var plexLibrary = await _dbContext.PlexLibraries.GetAsync(req.PlexLibraryId, ct);
             if (plexLibrary is null)
             {
@@ -55,7 +96,6 @@ public class GetLibraryMediaMetadata : BaseEndpoint<GetLibraryMediaMetadataReque
                 return;
             }
 
-            // Get actual data efficiently using joins
             var roles = await (
                 from la in _dbContext.PlexLibraryActors
                 join a in _dbContext.PlexActors on la.PlexActorId equals a.Id
@@ -77,93 +117,191 @@ public class GetLibraryMediaMetadata : BaseEndpoint<GetLibraryMediaMetadataReque
                 select new PlexGenreDTO { Id = g.Id, Name = g.Name }
             ).ToListAsync(ct);
 
-            var uniqueQualities = await GetQualitiesForMediaType(req.MediaType, req.PlexLibraryId, ct);
-
-            var mediaMetadataDTO = new PlexMediaMetadataDTO
-            {
-                MediaCount = plexLibrary.MediaCount,
-                Roles = roles,
-                Countries = countries,
-                Genres = genres,
-                Qualities = uniqueQualities,
-                RoleCount = plexLibrary.ActorsCount,
-                CountryCount = plexLibrary.CountriesCount,
-                GenreCount = plexLibrary.GenresCount,
-                QualityCount = uniqueQualities.Count,
-            };
-
-            await SendFluentResult(Result.Ok(mediaMetadataDTO), ct);
-        }
-        else
-        {
-            var mediaCount = await _dbContext
-                .PlexLibraries.Where(pl => pl.Type == req.MediaType)
-                .SumAsync(pl => pl.MediaCount, ct);
-
-            // Get counts efficiently for global metadata
-            var roleCount = await _dbContext
-                .PlexLibraries.Where(pl => pl.Type == req.MediaType)
-                .SelectMany(pl => pl.Actors)
-                .Select(a => a.Id)
-                .Distinct()
-                .CountAsync(ct);
-
-            var countryCount = await _dbContext
-                .PlexLibraries.Where(pl => pl.Type == req.MediaType)
-                .SelectMany(pl => pl.Countries)
-                .Select(c => c.Id)
-                .Distinct()
-                .CountAsync(ct);
-
-            var genreCount = await _dbContext
-                .PlexLibraries.Where(pl => pl.Type == req.MediaType)
-                .SelectMany(pl => pl.Genres)
-                .Select(g => g.Id)
-                .Distinct()
-                .CountAsync(ct);
-
-            // Get actual unique data efficiently
-            var uniqueRoles = await _dbContext
-                .PlexLibraries.Where(pl => pl.Type == req.MediaType)
-                .SelectMany(pl => pl.Actors)
-                .Select(a => new PlexRoleDTO { Id = a.Id, Name = a.Name })
-                .Distinct()
-                .ToListAsync(ct);
-
-            var uniqueCountries = await _dbContext
-                .PlexLibraries.Where(pl => pl.Type == req.MediaType)
-                .SelectMany(pl => pl.Countries)
-                .Select(c => new PlexCountryDTO { Id = c.Id, Name = c.Name })
-                .Distinct()
-                .ToListAsync(ct);
-
-            var uniqueGenres = await _dbContext
-                .PlexLibraries.Where(pl => pl.Type == req.MediaType)
-                .SelectMany(pl => pl.Genres)
-                .Select(g => new PlexGenreDTO { Id = g.Id, Name = g.Name })
-                .Distinct()
-                .ToListAsync(ct);
-
-            var uniqueQualities = await GetQualitiesForMediaType(req.MediaType, ct: ct);
+            var uniqueQualities2 = await GetQualitiesForMediaType(req.MediaType, req.PlexLibraryId, ct);
+            var navigationIndexes = await GetNavigationIndexes(req, ct);
 
             await SendFluentResult(
                 Result.Ok(
                     new PlexMediaMetadataDTO
                     {
-                        MediaCount = mediaCount,
-                        QualityCount = uniqueQualities.Count,
-                        Roles = uniqueRoles,
-                        Countries = uniqueCountries,
-                        Genres = uniqueGenres,
-                        RoleCount = roleCount,
-                        CountryCount = countryCount,
-                        GenreCount = genreCount,
-                        Qualities = uniqueQualities,
+                        MediaCount = plexLibrary.MediaCount,
+                        Roles = roles,
+                        Countries = countries,
+                        Genres = genres,
+                        Qualities = uniqueQualities2,
+                        RoleCount = plexLibrary.ActorsCount,
+                        CountryCount = plexLibrary.CountriesCount,
+                        GenreCount = plexLibrary.GenresCount,
+                        QualityCount = uniqueQualities2.Count,
+                        NavigationIndexes = navigationIndexes,
                     }
                 ),
                 ct
             );
+
+            return;
         }
+
+        var mediaCount = await _dbContext
+            .PlexLibraries.Where(pl => pl.Type == req.MediaType)
+            .SumAsync(pl => pl.MediaCount, ct);
+
+        var roleCount = await _dbContext
+            .PlexLibraries.Where(pl => pl.Type == req.MediaType)
+            .SelectMany(pl => pl.Actors)
+            .Select(a => a.Id)
+            .Distinct()
+            .CountAsync(ct);
+
+        var countryCount = await _dbContext
+            .PlexLibraries.Where(pl => pl.Type == req.MediaType)
+            .SelectMany(pl => pl.Countries)
+            .Select(c => c.Id)
+            .Distinct()
+            .CountAsync(ct);
+
+        var genreCount = await _dbContext
+            .PlexLibraries.Where(pl => pl.Type == req.MediaType)
+            .SelectMany(pl => pl.Genres)
+            .Select(g => g.Id)
+            .Distinct()
+            .CountAsync(ct);
+
+        var uniqueRoles = await _dbContext
+            .PlexLibraries.Where(pl => pl.Type == req.MediaType)
+            .SelectMany(pl => pl.Actors)
+            .Select(a => new PlexRoleDTO { Id = a.Id, Name = a.Name })
+            .Distinct()
+            .ToListAsync(ct);
+
+        var uniqueCountries = await _dbContext
+            .PlexLibraries.Where(pl => pl.Type == req.MediaType)
+            .SelectMany(pl => pl.Countries)
+            .Select(c => new PlexCountryDTO { Id = c.Id, Name = c.Name })
+            .Distinct()
+            .ToListAsync(ct);
+
+        var uniqueGenres = await _dbContext
+            .PlexLibraries.Where(pl => pl.Type == req.MediaType)
+            .SelectMany(pl => pl.Genres)
+            .Select(g => new PlexGenreDTO { Id = g.Id, Name = g.Name })
+            .Distinct()
+            .ToListAsync(ct);
+
+        var uniqueQualities = await GetQualitiesForMediaType(req.MediaType, ct: ct);
+        var allNavigationIndexes = await GetNavigationIndexes(req, ct);
+
+        await SendFluentResult(
+            Result.Ok(
+                new PlexMediaMetadataDTO
+                {
+                    MediaCount = mediaCount,
+                    QualityCount = uniqueQualities.Count,
+                    Roles = uniqueRoles,
+                    Countries = uniqueCountries,
+                    Genres = uniqueGenres,
+                    RoleCount = roleCount,
+                    CountryCount = countryCount,
+                    GenreCount = genreCount,
+                    Qualities = uniqueQualities,
+                    NavigationIndexes = allNavigationIndexes,
+                }
+            ),
+            ct
+        );
+    }
+
+    private async Task<Dictionary<string, int>> GetNavigationIndexes(GetLibraryMediaMetadataRequest req, CancellationToken ct)
+    {
+        var filter = new MediaQueryFilter
+        {
+            MediaType = req.MediaType,
+            PlexLibraryId = req.PlexLibraryId,
+            Skip = 0,
+            Take = 0,
+            FilterOfflineMedia = req.FilterOfflineMedia,
+            FilterOwnedMedia = req.FilterOwnedMedia,
+            CountryId = req.CountryId,
+            ActorId = req.ActorId,
+            GenreId = req.GenreId,
+            Quality = req.Quality,
+            Search = req.Search,
+            SortField = req.SortField,
+            SortDirection = req.SortDirection,
+        };
+
+        var result = await _dbContext.GetMediaByType(filter, ct);
+        if (result.IsFailed || result.Value.TotalCount == 0)
+        {
+            return [];
+        }
+
+        var items = result.Value.Items;
+        var indexes = new Dictionary<string, int>();
+
+        for (var i = 0; i < items.Count; i++)
+        {
+            var label = GetNavigationLabel(items[i], req.SortField);
+            if (string.IsNullOrWhiteSpace(label) || indexes.ContainsKey(label))
+            {
+                continue;
+            }
+
+            indexes[label] = i;
+        }
+
+        return indexes;
+    }
+
+    private static string GetNavigationLabel(PlexMediaSlimDTO item, string sortField)
+    {
+        return sortField switch
+        {
+            "year" => item.Year > 0 ? item.Year.ToString() : "#",
+            "quality" => ToQualityLabel(item.Qualities.MaxBy(x => (int)x.Quality)?.Quality ?? VideoQuality.Unknown),
+            "duration" => ToDurationBucket(item.Duration),
+            "addedAt" => item.AddedAt.ToString("MMM yyyy", System.Globalization.CultureInfo.InvariantCulture),
+            "updatedAt" => item.UpdatedAt?.ToString("MMM yyyy", System.Globalization.CultureInfo.InvariantCulture) ?? "#",
+            "mediaSize" => ToMediaSizeBucket(item.MediaSize),
+            _ => ToTitleBucket(item.Title),
+        };
+    }
+
+    private static string ToTitleBucket(string title)
+    {
+        var first = title.Trim().FirstOrDefault();
+        return char.IsLetter(first) ? char.ToUpperInvariant(first).ToString() : "#";
+    }
+
+    private static string ToDurationBucket(int seconds)
+    {
+        var start = Math.Max(0, seconds) / 600 * 10;
+        return $"{start}–{start + 10} min";
+    }
+
+    private static string ToMediaSizeBucket(long bytes)
+    {
+        var start = (int)Math.Floor((double)Math.Max(0, bytes) / Gigabyte);
+        return $"{start}–{start + 1} GB";
+    }
+
+    private static string ToQualityLabel(VideoQuality quality)
+    {
+        return quality switch
+        {
+            VideoQuality.SubSD_144p => "144p",
+            VideoQuality.SubSD_CIF => "240p",
+            VideoQuality.nHD => "360p",
+            VideoQuality.SD => "480p",
+            VideoQuality.DVD => "576p",
+            VideoQuality.HD => "720p",
+            VideoQuality.FullHD => "1080p",
+            VideoQuality.QHD => "1440p",
+            VideoQuality.UHD_4K => "4K",
+            VideoQuality.UHD_8K => "8K",
+            VideoQuality.Unknown => "Unknown",
+            _ => "None",
+        };
     }
 
     private async Task<List<PlexQualityDTO>> GetQualitiesForMediaType(

--- a/src/Application/PlexMedia/GetAll/GetAllMediaByTypeEndpoint.cs
+++ b/src/Application/PlexMedia/GetAll/GetAllMediaByTypeEndpoint.cs
@@ -31,6 +31,8 @@ public class GetAllMediaByTypeRequestValidator : Validator<GetAllMediaByTypeRequ
         RuleFor(x => x.Page).GreaterThanOrEqualTo(0);
         RuleFor(x => x.Size).GreaterThanOrEqualTo(0);
         RuleFor(x => x).Must(x => x.Size > 0 || x.Page == 0).WithMessage("Page must be 0 when size is 0.");
+        RuleFor(x => x.SortDirection).Must(x => x is "asc" or "desc");
+        RuleFor(x => x.SortField).Must(x => x is "sortIndex" or "year" or "addedAt" or "updatedAt" or "duration" or "mediaSize" or "quality");
     }
 }
 
@@ -81,6 +83,9 @@ public class GetAllMediaByTypeEndpoint : BaseEndpoint<GetAllMediaByTypeRequest, 
                 ActorId = req.ActorId,
                 GenreId = req.GenreId,
                 Quality = req.Quality,
+                Search = req.Search,
+                SortField = req.SortField,
+                SortDirection = req.SortDirection,
             },
             ct: ct
         );
@@ -93,6 +98,6 @@ public class GetAllMediaByTypeEndpoint : BaseEndpoint<GetAllMediaByTypeRequest, 
             return;
         }
 
-        await SendFluentResult(Result.Ok(mediaListResult.Value.ToStatisticsDTO()), ct);
+        await SendFluentResult(Result.Ok(mediaListResult.Value.Items.ToStatisticsDTO(mediaListResult.Value.TotalCount)), ct);
     }
 }

--- a/src/Application/_Shared/BaseRequests/PlexMediaFilterQueryRequest.cs
+++ b/src/Application/_Shared/BaseRequests/PlexMediaFilterQueryRequest.cs
@@ -13,7 +13,10 @@ public abstract record PlexMediaFilterQueryRequest
         int genreId = 0,
         VideoQuality quality = VideoQuality.None,
         bool filterOfflineMedia = false,
-        bool filterOwnedMedia = false
+        bool filterOwnedMedia = false,
+        string search = "",
+        string sortField = "sortIndex",
+        string sortDirection = "asc"
     )
     {
         Page = page;
@@ -24,6 +27,9 @@ public abstract record PlexMediaFilterQueryRequest
         Quality = quality;
         FilterOfflineMedia = filterOfflineMedia;
         FilterOwnedMedia = filterOwnedMedia;
+        Search = search;
+        SortField = sortField;
+        SortDirection = sortDirection;
     }
 
     [QueryParam, BindFrom("page")]
@@ -61,4 +67,16 @@ public abstract record PlexMediaFilterQueryRequest
     [QueryParam, BindFrom("filterOwnedMedia")]
     [DefaultValue(false)]
     public bool FilterOwnedMedia { get; init; }
+
+    [QueryParam, BindFrom("search")]
+    [DefaultValue("")]
+    public string Search { get; init; } = string.Empty;
+
+    [QueryParam, BindFrom("sortField")]
+    [DefaultValue("sortIndex")]
+    public string SortField { get; init; } = "sortIndex";
+
+    [QueryParam, BindFrom("sortDirection")]
+    [DefaultValue("asc")]
+    public string SortDirection { get; init; } = "asc";
 }

--- a/src/Data.Contracts/DTO/MediaQueryFilter.cs
+++ b/src/Data.Contracts/DTO/MediaQueryFilter.cs
@@ -21,4 +21,10 @@ public record MediaQueryFilter
     public required int GenreId { get; init; }
 
     public required VideoQuality Quality { get; init; }
+
+    public required string Search { get; init; }
+
+    public required string SortField { get; init; }
+
+    public required string SortDirection { get; init; }
 }

--- a/src/Data.Contracts/DTO/PagedMediaQueryResult.cs
+++ b/src/Data.Contracts/DTO/PagedMediaQueryResult.cs
@@ -1,0 +1,8 @@
+namespace Reaparr.Data.Contracts;
+
+public record PagedMediaQueryResult
+{
+    public required List<PlexMediaSlimDTO> Items { get; init; }
+
+    public required int TotalCount { get; init; }
+}

--- a/src/Data.Contracts/Extensions/DbContext/DbContextExtensions.PlexMedia.cs
+++ b/src/Data.Contracts/Extensions/DbContext/DbContextExtensions.PlexMedia.cs
@@ -65,13 +65,12 @@ public static partial class DbContextExtensions
         );
     }
 
-    public static async Task<Result<List<PlexMediaSlimDTO>>> GetMediaByType(
+    public static async Task<Result<PagedMediaQueryResult>> GetMediaByType(
         this IReaparrDbContext dbContext,
         MediaQueryFilter filter,
         CancellationToken ct = default
     )
     {
-        List<PlexMediaSlimDTO> plexMediaSlimDtos;
         var plexLibraryId = filter.PlexLibraryId;
 
         var serverList = await dbContext.PlexServers
@@ -102,7 +101,11 @@ public static partial class DbContextExtensions
         }
 
         if (plexLibraryId == 0 && !allowedPlexLibraryIds.Any())
-            return Result.Ok(new List<PlexMediaSlimDTO>());
+            return Result.Ok(new PagedMediaQueryResult { Items = [], TotalCount = 0 });
+
+        var sortField = filter.SortField.Trim();
+        var sortDirection = filter.SortDirection.Trim().ToLowerInvariant();
+        var search = filter.Search.Trim().ToLowerInvariant();
 
         switch (filter.MediaType)
         {
@@ -119,25 +122,23 @@ public static partial class DbContextExtensions
                 if (filter.ActorId > 0)
                     query = query.Include(x => x.Actors);
 
-                var movies = await query
+                query = query
                     .Include(x => x.MediaDataList)
                     .ApplyWhere(plexLibraryId > 0, x => x.PlexLibraryId == plexLibraryId)
                     .ApplyWhere(plexLibraryId == 0, x => allowedPlexLibraryIds.Contains(x.PlexLibraryId))
                     .ApplyWhere(filter.CountryId > 0, x => x.Countries.Any(y => y.Id == filter.CountryId))
                     .ApplyWhere(filter.GenreId > 0, x => x.Genres.Any(y => y.Id == filter.GenreId))
                     .ApplyWhere(filter.ActorId > 0, x => x.Actors.Any(y => y.Id == filter.ActorId))
-                    .ApplyWhere(
-                        filter.Quality != VideoQuality.None,
-                        x => x.MediaDataList.Any(y => y.Quality == filter.Quality)
-                    )
-                    .ApplyOrderBy(plexLibraryId > 0, x => x.SortIndex)
-                    .ApplySkip(filter.Skip)
-                    .ApplyTake(filter.Take)
-                    .ToListAsync(ct);
+                    .ApplyWhere(filter.Quality != VideoQuality.None, x => x.MediaDataList.Any(y => y.Quality == filter.Quality))
+                    .ApplyWhere(!string.IsNullOrWhiteSpace(search), x => x.SearchTitle.ToLower().Contains(search));
 
-                plexMediaSlimDtos = movies.Select(x => x.ToSlimDTO()).ToList();
+                query = ApplyMovieSort(query, sortField, sortDirection);
 
-                break;
+                var totalCount = await query.CountAsync(ct);
+                var take = filter.Take <= 0 ? totalCount : filter.Take;
+                var items = await query.ApplySkip(filter.Skip).ApplyTake(take).Select(x => x.ToSlimDTO()).ToListAsync(ct);
+
+                return Result.Ok(new PagedMediaQueryResult { Items = items, TotalCount = totalCount });
             }
             case PlexMediaType.TvShow:
             {
@@ -152,44 +153,61 @@ public static partial class DbContextExtensions
                 if (filter.ActorId > 0)
                     query = query.Include(x => x.Actors);
 
-                var tvShows = await query
+                query = query
                     .Include(x => x.Qualities)
                     .ApplyWhere(plexLibraryId > 0, x => x.PlexLibraryId == plexLibraryId)
                     .ApplyWhere(plexLibraryId == 0, x => allowedPlexLibraryIds.Contains(x.PlexLibraryId))
                     .ApplyWhere(filter.CountryId > 0, x => x.Countries.Any(y => y.Id == filter.CountryId))
                     .ApplyWhere(filter.GenreId > 0, x => x.Genres.Any(y => y.Id == filter.GenreId))
                     .ApplyWhere(filter.ActorId > 0, x => x.Actors.Any(y => y.Id == filter.ActorId))
-                    .ApplyWhere(
-                        filter.Quality != VideoQuality.None,
-                        x => x.Qualities.Any(y => y.Quality == filter.Quality)
-                    )
-                    .ApplyOrderBy(plexLibraryId > 0, x => x.SortIndex)
-                    .ApplySkip(filter.Skip)
-                    .ApplyTake(filter.Take)
-                    .ToListAsync(ct);
+                    .ApplyWhere(filter.Quality != VideoQuality.None, x => x.Qualities.Any(y => y.Quality == filter.Quality))
+                    .ApplyWhere(!string.IsNullOrWhiteSpace(search), x => x.SearchTitle.ToLower().Contains(search));
 
-                plexMediaSlimDtos = tvShows.Select(x => x.ToSlimDTOMapper()).ToList();
-                break;
+                query = ApplyTvShowSort(query, sortField, sortDirection);
+
+                var totalCount = await query.CountAsync(ct);
+                var take = filter.Take <= 0 ? totalCount : filter.Take;
+                var items = await query.ApplySkip(filter.Skip).ApplyTake(take).Select(x => x.ToSlimDTOMapper()).ToListAsync(ct);
+
+                return Result.Ok(new PagedMediaQueryResult { Items = items, TotalCount = totalCount });
             }
             default:
-                return Result.Fail(
-                    $"Type {filter.MediaType} is not supported for retrieving the PlexMedia data by library id"
-                );
+                return Result.Fail($"Type {filter.MediaType} is not supported for retrieving the PlexMedia data by library id");
         }
+    }
 
-        if (plexLibraryId == 0)
-            plexMediaSlimDtos = plexMediaSlimDtos.OrderByNatural(x => x.SearchTitle).ToList();
-
-        // Add token to retrieve thumbnail in front-end
-        for (var i = 0; i < plexMediaSlimDtos.Count; i++)
+    private static IQueryable<PlexMovie> ApplyMovieSort(IQueryable<PlexMovie> query, string sortField, string sortDirection)
+    {
+        var asc = sortDirection != "desc";
+        return sortField switch
         {
-            var slimDTO = plexMediaSlimDtos[i];
+            "year" => asc ? query.OrderBy(x => x.Year).ThenBy(x => x.SearchTitle) : query.OrderByDescending(x => x.Year).ThenByDescending(x => x.SearchTitle),
+            "addedAt" => asc ? query.OrderBy(x => x.AddedAt).ThenBy(x => x.SearchTitle) : query.OrderByDescending(x => x.AddedAt).ThenByDescending(x => x.SearchTitle),
+            "updatedAt" => asc ? query.OrderBy(x => x.UpdatedAt).ThenBy(x => x.SearchTitle) : query.OrderByDescending(x => x.UpdatedAt).ThenByDescending(x => x.SearchTitle),
+            "duration" => asc ? query.OrderBy(x => x.Duration).ThenBy(x => x.SearchTitle) : query.OrderByDescending(x => x.Duration).ThenByDescending(x => x.SearchTitle),
+            "mediaSize" => asc ? query.OrderBy(x => x.MediaSize).ThenBy(x => x.SearchTitle) : query.OrderByDescending(x => x.MediaSize).ThenByDescending(x => x.SearchTitle),
+            "quality" => asc
+                ? query.OrderBy(x => x.MediaDataList.Max(y => (int?)y.Quality) ?? 0).ThenBy(x => x.SearchTitle)
+                : query.OrderByDescending(x => x.MediaDataList.Max(y => (int?)y.Quality) ?? 0).ThenByDescending(x => x.SearchTitle),
+            _ => asc ? query.OrderBy(x => x.SortIndex).ThenBy(x => x.SearchTitle) : query.OrderByDescending(x => x.SortIndex).ThenByDescending(x => x.SearchTitle),
+        };
+    }
 
-            slimDTO.SortIndex = i + 1;
-        }
-
-        // If the plexLibraryId is set, we don't need to sort the list again
-        return Result.Ok(plexMediaSlimDtos);
+    private static IQueryable<PlexTvShow> ApplyTvShowSort(IQueryable<PlexTvShow> query, string sortField, string sortDirection)
+    {
+        var asc = sortDirection != "desc";
+        return sortField switch
+        {
+            "year" => asc ? query.OrderBy(x => x.Year).ThenBy(x => x.SearchTitle) : query.OrderByDescending(x => x.Year).ThenByDescending(x => x.SearchTitle),
+            "addedAt" => asc ? query.OrderBy(x => x.AddedAt).ThenBy(x => x.SearchTitle) : query.OrderByDescending(x => x.AddedAt).ThenByDescending(x => x.SearchTitle),
+            "updatedAt" => asc ? query.OrderBy(x => x.UpdatedAt).ThenBy(x => x.SearchTitle) : query.OrderByDescending(x => x.UpdatedAt).ThenByDescending(x => x.SearchTitle),
+            "duration" => asc ? query.OrderBy(x => x.Duration).ThenBy(x => x.SearchTitle) : query.OrderByDescending(x => x.Duration).ThenByDescending(x => x.SearchTitle),
+            "mediaSize" => asc ? query.OrderBy(x => x.MediaSize).ThenBy(x => x.SearchTitle) : query.OrderByDescending(x => x.MediaSize).ThenByDescending(x => x.SearchTitle),
+            "quality" => asc
+                ? query.OrderBy(x => x.Qualities.Max(y => (int?)y.Quality) ?? 0).ThenBy(x => x.SearchTitle)
+                : query.OrderByDescending(x => x.Qualities.Max(y => (int?)y.Quality) ?? 0).ThenByDescending(x => x.SearchTitle),
+            _ => asc ? query.OrderBy(x => x.SortIndex).ThenBy(x => x.SearchTitle) : query.OrderByDescending(x => x.SortIndex).ThenByDescending(x => x.SearchTitle),
+        };
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes UNKNOWN owner by applying lsiown with numeric PUID:PGID instead of abc:abc in reaparr run script.

Ref: https://github.com/Reaparr/Reaparr/issues/578#issuecomment-4391444667

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sorting support for media by year, date added, date updated, duration, media size, and quality.
  * Added filtering options by video quality, media ownership status, and online availability.
  * Implemented pagination for media queries with total count information.
  * Added navigation indexes to enhance result navigation and organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->