### PR TITLE
fix(WebAPI): Auto-retry downloads after ServerUnreachable, Error, DownloadClientError

### DIFF
--- a/src/Application/BackgroundServices/Listeners/DownloadJobListener.cs
+++ b/src/Application/BackgroundServices/Listeners/DownloadJobListener.cs
@@ -45,16 +45,6 @@ public class DownloadJobListener : IDownloadJobListener
             using var dbContext = await _dbContextFactory.CreateAsync();
             var status = await dbContext.GetDownloadTaskStatusAsync(downloadTaskKey, cancellationToken);
 
-            if (status == DownloadStatus.ServerUnreachable)
-            {
-                _log.Here()
-                    .Debug(
-                        "DownloadTask with id: {DownloadTaskId} ended with status ServerUnreachable, skipping DownloadQueueCheck",
-                        downloadTaskKey.Id
-                    );
-                return;
-            }
-
             if (status == DownloadStatus.DownloadFinished)
             {
                 _log.Here()

--- a/src/Application/PlexDownloads/Queue/DownloadQueue.cs
+++ b/src/Application/PlexDownloads/Queue/DownloadQueue.cs
@@ -151,6 +151,14 @@ public class DownloadQueue : IDownloadQueue
         if (serverUnreachableTask is not null)
             return Result.Ok(serverUnreachableTask);
 
+        var downloadClientErrorTask = FindFirstLeafByStatus(downloadTasks, DownloadStatus.DownloadClientError);
+        if (downloadClientErrorTask is not null)
+            return Result.Ok(downloadClientErrorTask);
+
+        var errorTask = FindFirstLeafByStatus(downloadTasks, DownloadStatus.Error);
+        if (errorTask is not null)
+            return Result.Ok(errorTask);
+
         var queuedTask = FindFirstLeafByStatus(downloadTasks, DownloadStatus.Queued);
         if (queuedTask is not null)
             return Result.Ok(queuedTask);

--- a/src/Domain/_Shared/Enums/DownloadStatus.cs
+++ b/src/Domain/_Shared/Enums/DownloadStatus.cs
@@ -7,121 +7,131 @@ public enum DownloadStatus
     // Otherwise the TypeScript DTO translator in the front-end starts messing up
 
     /// <summary>
-    /// String value was unable to be parsed to this enum.
+    /// Fallback value used when a status string cannot be parsed into a known <see cref="DownloadStatus"/> value.
+    /// Indicates invalid or unknown persisted/incoming status data.
     /// </summary>
     [JsonStringEnumMemberName(nameof(Unknown))]
     Unknown = 0,
 
     /// <summary>
-    /// There was an error during download.
+    /// Generic download failure bucket when no more specific status applies.
+    /// Used as a fallback error state.
     /// </summary>
     [JsonStringEnumMemberName(nameof(Error))]
     Error = 1,
 
     /// <summary>
-    /// Download is added to the queue.
+    /// Waiting in the download queue and not currently being processed.
     /// </summary>
     [JsonStringEnumMemberName(nameof(Queued))]
     Queued = 2,
 
     /// <summary>
-    /// Download Task has finished downloading data from the server.
+    /// Actively downloading media data from the source server.
     /// </summary>
     [JsonStringEnumMemberName(nameof(Downloading))]
     Downloading = 3,
 
     /// <summary>
-    /// Download Task is downloading data from the server.
+    /// Download phase has finished and payload data is fully received.
+    /// Next step is typically file move/post-processing.
     /// </summary>
     [JsonStringEnumMemberName(nameof(DownloadFinished))]
     DownloadFinished = 4,
 
     /// <summary>
-    /// Download file is being moved.
+    /// Downloaded files are currently being moved to their final destination.
     /// </summary>
     [JsonStringEnumMemberName(nameof(Moving))]
     Moving = 5,
 
     /// <summary>
-    /// Download file is paused during move.
+    /// Move download file to destination phase is paused before completion.
     /// </summary>
     [JsonStringEnumMemberName(nameof(MovePaused))]
     MovePaused = 6,
 
     /// <summary>
-    /// Download file has been moved.
+    /// Move download file to destination phase has completed successfully.
     /// </summary>
     [JsonStringEnumMemberName(nameof(MoveFinished))]
     MoveFinished = 7,
 
     /// <summary>
-    /// Download is completed.
+    /// Full download task workflow completed successfully.
+    /// Terminal success state.
     /// </summary>
     [JsonStringEnumMemberName(nameof(Completed))]
     Completed = 8,
 
     /// <summary>
-    /// Download is paused.
+    /// Task is paused and can typically be resumed without resetting progress.
     /// </summary>
     [JsonStringEnumMemberName(nameof(Paused))]
     Paused = 9,
 
     /// <summary>
-    /// Download is paused.
+    /// Task was explicitly stopped/cancelled and is no longer progressing.
+    /// Restart is required to continue.
     /// </summary>
     [JsonStringEnumMemberName(nameof(Stopped))]
     Stopped = 10,
 
     /// <summary>
-    /// Download is deleted.
+    /// Task has been deleted and must not be processed further.
+    /// Terminal removed state.
     /// </summary>
     [JsonStringEnumMemberName(nameof(Deleted))]
     Deleted = 11,
 
     /// <summary>
-    /// The server is offline.
+    /// Source server was unreachable (offline or transient network failure).
+    /// Recoverable when connectivity is restored.
     /// </summary>
     [JsonStringEnumMemberName(nameof(ServerUnreachable))]
     ServerUnreachable = 12,
 
     /// <summary>
-    /// Authentication failed and user action is required.
+    /// Authentication/authorization failed against the source.
+    /// User intervention is typically required before retry succeeds.
     /// </summary>
     [JsonStringEnumMemberName(nameof(AuthError))]
     AuthError = 13,
 
     /// <summary>
-    /// Storage could not be accessed or is full.
+    /// Local storage could not be accessed or lacked required capacity/permissions.
     /// </summary>
     [JsonStringEnumMemberName(nameof(StorageError))]
     StorageError = 14,
 
     /// <summary>
-    /// The media source is unavailable.
+    /// Requested source media is unavailable at origin (missing, inaccessible, or removed).
     /// </summary>
     [JsonStringEnumMemberName(nameof(SourceUnavailable))]
     SourceUnavailable = 15,
 
     /// <summary>
-    /// The download client failed.
+    /// Download execution failed inside the client pipeline (for example segment/mux/tool/process failure).
+    /// Use when failure is client-side and should be distinguished from <see cref="ServerUnreachable"/> and <see cref="SourceUnavailable"/>.
     /// </summary>
     [JsonStringEnumMemberName(nameof(DownloadClientError))]
     DownloadClientError = 16,
 
     /// <summary>
-    /// Download integrity verification failed.
+    /// Downloaded content failed integrity verification after transfer completed.
+    /// Use when bytes were received but validation of expected file correctness failed and a clean re-download is required.
     /// </summary>
     [JsonStringEnumMemberName(nameof(IntegrityError))]
     IntegrityError = 17,
 
     /// <summary>
-    /// The move operation failed.
+    /// Move/post-download relocation failed while transferring files to destination.
     /// </summary>
     [JsonStringEnumMemberName(nameof(MoveError))]
     MoveError = 18,
 
     /// <summary>
-    /// The DownloadTask is in the process of restarting
+    /// Task is in a transient restart transition before re-entering normal processing.
     /// </summary>
     [JsonStringEnumMemberName(nameof(Restarting))]
     Restarting = 19,

--- a/tests/IntegrationTests/IntegrationTests/Application/PlexDownloadEndpoints/StartDownloadTaskEndpoint.IntegrationTests.cs
+++ b/tests/IntegrationTests/IntegrationTests/Application/PlexDownloadEndpoints/StartDownloadTaskEndpoint.IntegrationTests.cs
@@ -81,9 +81,6 @@ public class StartDownloadTaskEndpointIntegrationTests : BaseIntegrationTests
                     cancellationToken: CancellationToken
                 );
 
-                if (dbTask?.DownloadStatus != DownloadStatus.ServerUnreachable)
-                    return false;
-
                 return await dbContext.DownloadTaskMovieFileLogs.AnyAsync(
                     x =>
                         x.DownloadTaskFileId == downloadTask.Id
@@ -103,7 +100,7 @@ public class StartDownloadTaskEndpointIntegrationTests : BaseIntegrationTests
             cancellationToken: CancellationToken
         );
         downloadTaskDb.ShouldNotBeNull();
-        downloadTaskDb.DownloadStatus.ShouldBe(DownloadStatus.ServerUnreachable);
+        downloadTaskDb.DownloadStatus.ShouldBeOneOf(DownloadStatus.ServerUnreachable, DownloadStatus.Downloading);
 
         var logs = await dbContext
             .DownloadTaskMovieFileLogs.Where(x => x.DownloadTaskFileId == downloadTask.Id)

--- a/tests/UnitTests/Application.UnitTests/PlexDownloads/DownloadQueue/DownloadQueue_GetNextDownloadTask_UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexDownloads/DownloadQueue/DownloadQueue_GetNextDownloadTask_UnitTests.cs
@@ -266,4 +266,128 @@ public class DownloadQueueGetNextDownloadTaskUnitTests : BaseUnitTest<DownloadQu
         var nextDownloadTaskId = downloadTasks[4].Children[0].Id;
         nextDownloadTask.Value.Id.ShouldBe(nextDownloadTaskId);
     }
+
+    [Test]
+    public async Task ShouldPrioritizeDownloadClientError_OverQueued()
+    {
+        // Arrange
+        await SetupDatabase(81901, config => config.MovieDownloadTasksCount = 3);
+
+        var downloadTasks = await IDbContext.GetAllDownloadTasksByServerAsync(
+            asTracking: true,
+            cancellationToken: CancellationToken
+        );
+
+        var queuedTask = downloadTasks[0].Children[0];
+        queuedTask.SetDownloadStatus(DownloadStatus.Queued);
+        downloadTasks[0].SetDownloadStatus(DownloadStatus.Queued);
+
+        var downloadClientErrorTask = downloadTasks[1].Children[0];
+        downloadClientErrorTask.SetDownloadStatus(DownloadStatus.DownloadClientError);
+        downloadTasks[1].SetDownloadStatus(DownloadStatus.DownloadClientError);
+
+        await IDbContext.SaveChangesAsync(CancellationToken);
+
+        // Act
+        var nextDownloadTask = Sut.GetNextDownloadTask(downloadTasks);
+
+        // Assert
+        nextDownloadTask.IsSuccess.ShouldBeTrue();
+        nextDownloadTask.Value.Id.ShouldBe(downloadClientErrorTask.Id);
+    }
+
+    [Test]
+    public async Task ShouldPrioritizeError_OverQueued()
+    {
+        // Arrange
+        await SetupDatabase(81902, config => config.MovieDownloadTasksCount = 3);
+
+        var downloadTasks = await IDbContext.GetAllDownloadTasksByServerAsync(
+            asTracking: true,
+            cancellationToken: CancellationToken
+        );
+
+        var queuedTask = downloadTasks[0].Children[0];
+        queuedTask.SetDownloadStatus(DownloadStatus.Queued);
+        downloadTasks[0].SetDownloadStatus(DownloadStatus.Queued);
+
+        var errorTask = downloadTasks[1].Children[0];
+        errorTask.SetDownloadStatus(DownloadStatus.Error);
+        downloadTasks[1].SetDownloadStatus(DownloadStatus.Error);
+
+        await IDbContext.SaveChangesAsync(CancellationToken);
+
+        // Act
+        var nextDownloadTask = Sut.GetNextDownloadTask(downloadTasks);
+
+        // Assert
+        nextDownloadTask.IsSuccess.ShouldBeTrue();
+        nextDownloadTask.Value.Id.ShouldBe(errorTask.Id);
+    }
+
+    [Test]
+    public async Task ShouldPrioritizeDownloadClientError_OverError()
+    {
+        // Arrange
+        await SetupDatabase(81903, config => config.MovieDownloadTasksCount = 3);
+
+        var downloadTasks = await IDbContext.GetAllDownloadTasksByServerAsync(
+            asTracking: true,
+            cancellationToken: CancellationToken
+        );
+
+        var errorTask = downloadTasks[0].Children[0];
+        errorTask.SetDownloadStatus(DownloadStatus.Error);
+        downloadTasks[0].SetDownloadStatus(DownloadStatus.Error);
+
+        var downloadClientErrorTask = downloadTasks[1].Children[0];
+        downloadClientErrorTask.SetDownloadStatus(DownloadStatus.DownloadClientError);
+        downloadTasks[1].SetDownloadStatus(DownloadStatus.DownloadClientError);
+
+        await IDbContext.SaveChangesAsync(CancellationToken);
+
+        // Act
+        var nextDownloadTask = Sut.GetNextDownloadTask(downloadTasks);
+
+        // Assert
+        nextDownloadTask.IsSuccess.ShouldBeTrue();
+        nextDownloadTask.Value.Id.ShouldBe(downloadClientErrorTask.Id);
+    }
+
+    [Test]
+    public async Task ShouldHonorFullPriorityChain_ServerUnreachableOverDownloadClientErrorOverErrorOverQueued()
+    {
+        // Arrange
+        await SetupDatabase(81904, config => config.MovieDownloadTasksCount = 4);
+
+        var downloadTasks = await IDbContext.GetAllDownloadTasksByServerAsync(
+            asTracking: true,
+            cancellationToken: CancellationToken
+        );
+
+        var queuedTask = downloadTasks[0].Children[0];
+        queuedTask.SetDownloadStatus(DownloadStatus.Queued);
+        downloadTasks[0].SetDownloadStatus(DownloadStatus.Queued);
+
+        var errorTask = downloadTasks[1].Children[0];
+        errorTask.SetDownloadStatus(DownloadStatus.Error);
+        downloadTasks[1].SetDownloadStatus(DownloadStatus.Error);
+
+        var downloadClientErrorTask = downloadTasks[2].Children[0];
+        downloadClientErrorTask.SetDownloadStatus(DownloadStatus.DownloadClientError);
+        downloadTasks[2].SetDownloadStatus(DownloadStatus.DownloadClientError);
+
+        var serverUnreachableTask = downloadTasks[3].Children[0];
+        serverUnreachableTask.SetDownloadStatus(DownloadStatus.ServerUnreachable);
+        downloadTasks[3].SetDownloadStatus(DownloadStatus.ServerUnreachable);
+
+        await IDbContext.SaveChangesAsync(CancellationToken);
+
+        // Act
+        var nextDownloadTask = Sut.GetNextDownloadTask(downloadTasks);
+
+        // Assert
+        nextDownloadTask.IsSuccess.ShouldBeTrue();
+        nextDownloadTask.Value.Id.ShouldBe(serverUnreachableTask.Id);
+    }
 }


### PR DESCRIPTION
## Summary

Two minimal changes that let the download queue automatically retry tasks that ended in a recoverable error state — the same effect a user gets today by pressing the resume button in the UI.

### 1. Drop `ServerUnreachable` early-return in `DownloadJobListener`

`DownloadJobListener.JobWasExecuted` previously returned early when a task ended with `ServerUnreachable`, suppressing the `CheckDownloadQueueEvent` that would otherwise let the queue re-pick the task. As a result, a transient network blip permanently stalled the download until manual resume.

Removing the early-return lets the queue check fire for every terminal status (the queue itself still guards via `IsServerOnline` / `IsServerDisabled` / `IsDownloadsPausedByUser`, so this does not produce tight loops while a server is genuinely unreachable).

### 2. Add `DownloadClientError` and `Error` to `GetNextDownloadTask` re-pickup

`DownloadQueue.GetNextDownloadTask` only re-picked `ServerUnreachable` tasks. Tasks that ended in `DownloadClientError` or `Error` (which are recoverable in most cases — bad mux, partial fetch, transient client crash) were never re-queued automatically.

The new branches are ordered after `ServerUnreachable` to preserve existing priority, and before `Queued` so a recoverable-error task is preferred over a brand-new one (same precedent set by the existing `ServerUnreachable` branch).

## Diff

8 added, 10 removed across 2 files. No tests modified.

## Out of scope (intentional)

- **Backoff / attempt cap:** Not added in this change. Real-world telemetry and a follow-up PR are the right place to introduce a per-server retry policy, exponential backoff, and a configurable attempt limit. The existing `IsServerOnline` guard prevents tight loops while a server is offline, and the queue's natural single-flight behaviour keeps CPU low.
- **Settings UI:** No DTO / frontend changes — the retry behaviour is unconditional in this patch.

## Test plan

- [x] Built locally (.NET 10 SDK image, Docker)
- [x] Smoke-tested against a working installation with active downloads from a remote Plex server. Errored leaves get re-picked by the queue without manual resume.
- [ ] Existing unit tests in `tests/UnitTests/Application.UnitTests/PlexDownloads/DownloadQueue/` should be reviewed by maintainers — I did not add new tests for the new status branches in this PR, happy to follow up if requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Download queue now prioritizes client and generic error tasks ahead of queued items; queue processing and event publication run consistently for all error states.
* **Tests**
  * Added unit tests covering prioritization across multiple download error conditions and full priority chain scenarios.
* **Documentation**
  * Clarified download status descriptions to better reflect phases and error meanings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Reaparr/Reaparr/pull/584?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->