### PR TITLE
feat(WebAPI): Auto-refresh stale Plex part IDs on 404 before failing a download

### DIFF
--- a/src/AppHost/Boot.cs
+++ b/src/AppHost/Boot.cs
@@ -81,6 +81,13 @@ public class Boot : IHostedService
             return;
         }
 
+        // Reset any download tasks left in Downloading from a previous run before the scheduler
+        // starts. Without this, the queue picker treats a zombie task as an active download and
+        // never picks a new one for that server.
+        var recoverResult = await _downloadQueue.RecoverInterruptedDownloadsAsync(cancellationToken);
+        if (recoverResult.IsFailed)
+            recoverResult.LogError();
+
         await _schedulerService.SetupAsync();
 
         var librarySyncListenerSetup = _librarySyncJobListener.Setup();

--- a/src/Application.Contracts/PlexDownloads/Queue/IDownloadQueue.cs
+++ b/src/Application.Contracts/PlexDownloads/Queue/IDownloadQueue.cs
@@ -6,4 +6,15 @@ public interface IDownloadQueue : ISetup, IBusy
     /// Check the DownloadQueue for downloadTasks which can be started.
     /// </summary>
     Task<Result> CheckDownloadQueue(List<int> plexServerIds);
+
+    /// <summary>
+    /// Resets any download tasks still in <see cref="DownloadStatus.Downloading"/> back to
+    /// <see cref="DownloadStatus.Queued"/>. A task can be left in <see cref="DownloadStatus.Downloading"/>
+    /// when the process is killed mid-download (OOM, container restart) and the
+    /// <c>DownloadFileCompleted</c> handler never fires. Without this sweep on boot, the queue
+    /// picker treats the zombie as an active download and never picks a new task for that server.
+    /// Persisted progress (offsets, snapshot) is preserved so the next attempt resumes from where
+    /// it left off.
+    /// </summary>
+    Task<Result> RecoverInterruptedDownloadsAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Application/PlexDownloads/Execute/DashDownloadClient/DashPlexDownloadClient.cs
+++ b/src/Application/PlexDownloads/Execute/DashDownloadClient/DashPlexDownloadClient.cs
@@ -255,6 +255,23 @@ public class DashPlexDownloadClient : IPlexDownloadClient
 
         if (!completed.IsSuccess)
         {
+            // Dash failure: dash-mpd-cli returns 404 when the manifest's part id is stale.
+            // Try refreshing IDs once before transitioning to SourceUnavailable.
+            if (
+                await _commandExecutor.TryRefreshIfStaleIdAsync(
+                    key.Id,
+                    key.Type,
+                    completed.Result,
+                    CancellationToken.None
+                )
+            )
+            {
+                var requeue = await SetDownloadStatusAsync(DownloadStatus.Queued);
+                if (requeue.IsFailed)
+                    requeue.LogError();
+                return;
+            }
+
             var status =
                 completed.Result.Has404NotFoundError() ? DownloadStatus.SourceUnavailable
                 : completed.Result.IsServerUnreachable() ? DownloadStatus.ServerUnreachable

--- a/src/Application/PlexDownloads/Execute/DirectDownloadClient/DirectPlexDownloadClient.cs
+++ b/src/Application/PlexDownloads/Execute/DirectDownloadClient/DirectPlexDownloadClient.cs
@@ -87,6 +87,31 @@ public class DirectPlexDownloadClient : IPlexDownloadClient
         if (downloadUrlResult.IsFailed)
         {
             var failedResult = downloadUrlResult.ToResult();
+
+            // 404 = the stored Plex part id no longer resolves. Most often this means the source
+            // server was re-scanned and the IDs rotated. Try refreshing the task's IDs against
+            // the latest synced library data once before giving up; if a newer match is found
+            // we reset the task to Queued so the picker re-tries with the corrected URL.
+            if (failedResult.Has404NotFoundError() && downloadTask.DownloadTaskType is DownloadTaskType.EpisodeData or DownloadTaskType.MovieData)
+            {
+                var refreshResult = await _commandExecutor.Send(
+                    new RefreshDownloadTaskMetadataCommand(downloadTask.Id, downloadTask.DownloadTaskType),
+                    cancellationToken
+                );
+                if (refreshResult.IsSuccess && refreshResult.Value)
+                {
+                    _log.Here()
+                        .Information(
+                            "Auto-refreshed metadata for {MediaFileName}; resetting status to Queued for retry",
+                            _filename
+                        );
+                    var requeueResult = await SetDownloadStatusAsync(Domain.DownloadStatus.Queued);
+                    if (requeueResult.IsFailed)
+                        return requeueResult;
+                    return Result.Ok();
+                }
+            }
+
             var failureStatus =
                 failedResult.Has404NotFoundError() ? Domain.DownloadStatus.SourceUnavailable
                 : failedResult.IsServerUnreachable() ? Domain.DownloadStatus.ServerUnreachable

--- a/src/Application/PlexDownloads/Execute/DirectDownloadClient/DirectPlexDownloadClient.cs
+++ b/src/Application/PlexDownloads/Execute/DirectDownloadClient/DirectPlexDownloadClient.cs
@@ -276,10 +276,12 @@ public class DirectPlexDownloadClient : IPlexDownloadClient
 
                             // Mid-download 404 (server re-scanned while we were downloading): try
                             // refreshing IDs and re-queue rather than transition to SourceUnavailable.
+                            // SetupDownloadListeners doesn't have the downloadTask local in scope,
+                            // so use the DownloadTaskKey it was set up with.
                             if (
                                 await _commandExecutor.TryRefreshIfStaleIdAsync(
-                                    downloadTask.Id,
-                                    downloadTask.DownloadTaskType,
+                                    key.Id,
+                                    key.Type,
                                     downloadErrorResult,
                                     CancellationToken.None
                                 )

--- a/src/Application/PlexDownloads/Execute/DirectDownloadClient/DirectPlexDownloadClient.cs
+++ b/src/Application/PlexDownloads/Execute/DirectDownloadClient/DirectPlexDownloadClient.cs
@@ -88,28 +88,27 @@ public class DirectPlexDownloadClient : IPlexDownloadClient
         {
             var failedResult = downloadUrlResult.ToResult();
 
-            // 404 = the stored Plex part id no longer resolves. Most often this means the source
-            // server was re-scanned and the IDs rotated. Try refreshing the task's IDs against
-            // the latest synced library data once before giving up; if a newer match is found
-            // we reset the task to Queued so the picker re-tries with the corrected URL.
-            if (failedResult.Has404NotFoundError() && downloadTask.DownloadTaskType is DownloadTaskType.EpisodeData or DownloadTaskType.MovieData)
-            {
-                var refreshResult = await _commandExecutor.Send(
-                    new RefreshDownloadTaskMetadataCommand(downloadTask.Id, downloadTask.DownloadTaskType),
+            // 404 = the stored Plex part id no longer resolves. Try refreshing this task's IDs
+            // against the latest synced library data; on success, reset to Queued so the picker
+            // re-tries with the corrected URL.
+            if (
+                await _commandExecutor.TryRefreshIfStaleIdAsync(
+                    downloadTask.Id,
+                    downloadTask.DownloadTaskType,
+                    failedResult,
                     cancellationToken
-                );
-                if (refreshResult.IsSuccess && refreshResult.Value)
-                {
-                    _log.Here()
-                        .Information(
-                            "Auto-refreshed metadata for {MediaFileName}; resetting status to Queued for retry",
-                            _filename
-                        );
-                    var requeueResult = await SetDownloadStatusAsync(Domain.DownloadStatus.Queued);
-                    if (requeueResult.IsFailed)
-                        return requeueResult;
-                    return Result.Ok();
-                }
+                )
+            )
+            {
+                _log.Here()
+                    .Information(
+                        "Auto-refreshed metadata for {MediaFileName}; resetting status to Queued for retry",
+                        _filename
+                    );
+                var requeueResult = await SetDownloadStatusAsync(Domain.DownloadStatus.Queued);
+                if (requeueResult.IsFailed)
+                    return requeueResult;
+                return Result.Ok();
             }
 
             var failureStatus =
@@ -274,6 +273,28 @@ public class DirectPlexDownloadClient : IPlexDownloadClient
                         if (args.Error != null)
                         {
                             var downloadErrorResult = Result.Fail(new ExceptionalError(args.Error)).LogError();
+
+                            // Mid-download 404 (server re-scanned while we were downloading): try
+                            // refreshing IDs and re-queue rather than transition to SourceUnavailable.
+                            if (
+                                await _commandExecutor.TryRefreshIfStaleIdAsync(
+                                    downloadTask.Id,
+                                    downloadTask.DownloadTaskType,
+                                    downloadErrorResult,
+                                    CancellationToken.None
+                                )
+                            )
+                            {
+                                _log.Here()
+                                    .Information(
+                                        "Auto-refreshed metadata mid-download for {MediaFileName}; resetting to Queued for retry",
+                                        _filename
+                                    );
+                                var requeueResult = await SetDownloadStatusAsync(Domain.DownloadStatus.Queued);
+                                requeueResult.LogIfFailed();
+                                return;
+                            }
+
                             var failedStatus =
                                 downloadErrorResult.Has404NotFoundError() ? Domain.DownloadStatus.SourceUnavailable
                                 : downloadErrorResult.IsServerUnreachable() ? Domain.DownloadStatus.ServerUnreachable

--- a/src/Application/PlexDownloads/Execute/DirectDownloadClient/GetDirectDownloadUrlCommand.cs
+++ b/src/Application/PlexDownloads/Execute/DirectDownloadClient/GetDirectDownloadUrlCommand.cs
@@ -68,9 +68,11 @@ public class GetDirectDownloadUrlCommandHandler : ICommandHandler<GetDirectDownl
         if (statusCode != HttpStatusCode.Forbidden)
         {
             fallbackProbeCancellationTokenSource.Cancel();
-            return Result
-                .Fail($"Plex download URL probe failed with status {(int)statusCode} ({statusCode})")
-                .LogError();
+            // Attach the HTTP status code to the Result so downstream consumers can detect 404
+            // via Has404NotFoundError() and recover (e.g. trigger a metadata refresh) rather
+            // than treat every probe failure as a generic Error.
+            var msg = $"Plex download URL probe failed with status {(int)statusCode} ({statusCode})";
+            return Result.Fail(msg).AddStatusCode(statusCode, msg).LogError();
         }
 
         var fallbackProbeResult = await fallbackProbeTask;
@@ -80,13 +82,12 @@ public class GetDirectDownloadUrlCommandHandler : ICommandHandler<GetDirectDownl
         if (fallbackProbeResult.Value.IsSuccessStatusCode)
             return Result.Ok(downloadUrlWithFlag);
 
-        return Result
-            .Fail(
-                $"Plex download URL probe failed for both default URL and URL with download=1 flag. "
-                    + $"Default URL status: {(int)initialProbeResult.Value.StatusCode} ({initialProbeResult.Value.StatusCode}). "
-                    + $"Fallback URL status: {(int)fallbackProbeResult.Value.StatusCode} ({fallbackProbeResult.Value.StatusCode})"
-            )
-            .LogError();
+        var fallbackStatus = fallbackProbeResult.Value.StatusCode;
+        var fallbackMsg =
+            $"Plex download URL probe failed for both default URL and URL with download=1 flag. "
+            + $"Default URL status: {(int)statusCode} ({statusCode}). "
+            + $"Fallback URL status: {(int)fallbackStatus} ({fallbackStatus})";
+        return Result.Fail(fallbackMsg).AddStatusCode(fallbackStatus, fallbackMsg).LogError();
     }
 
     private async Task<Result<ProbeResult>> ProbeDownloadUrl(string downloadUrl, CancellationToken cancellationToken)

--- a/src/Application/PlexDownloads/Execute/DownloadJob.cs
+++ b/src/Application/PlexDownloads/Execute/DownloadJob.cs
@@ -136,19 +136,45 @@ public class DownloadJob : IJob
             }
             else if (startResult.IsFailed)
             {
-                var failedStatus =
-                    startResult.Has404NotFoundError() ? DownloadStatus.SourceUnavailable
-                    : startResult.IsServerUnreachable() ? DownloadStatus.ServerUnreachable
-                    : DownloadStatus.DownloadClientError;
+                // 404 here typically means the inner download client didn't catch the stale-id
+                // case (e.g. the Dash client, or a 404 that surfaces only at Quartz-job level).
+                // Try refreshing once before transitioning to SourceUnavailable.
+                if (
+                    await _commandExecutor.TryRefreshIfStaleIdAsync(
+                        downloadTask.Id,
+                        downloadTask.DownloadTaskType,
+                        startResult.ToResult(),
+                        token
+                    )
+                )
+                {
+                    _log.Here()
+                        .Information(
+                            "Auto-refreshed metadata for {FullTitle}; resetting status to Queued for retry",
+                            downloadTask.FullTitle
+                        );
+                    await _downloadTaskUpdateDispatcher.OnStatusChangedAsync(
+                        downloadTask.ToKey(),
+                        DownloadStatus.Queued,
+                        CancellationToken.None
+                    );
+                }
+                else
+                {
+                    var failedStatus =
+                        startResult.Has404NotFoundError() ? DownloadStatus.SourceUnavailable
+                        : startResult.IsServerUnreachable() ? DownloadStatus.ServerUnreachable
+                        : DownloadStatus.DownloadClientError;
 
-                await _downloadTaskUpdateDispatcher.OnStatusChangedAsync(
-                    downloadTask.ToKey(),
-                    failedStatus,
-                    startResult,
-                    CancellationToken.None
-                );
+                    await _downloadTaskUpdateDispatcher.OnStatusChangedAsync(
+                        downloadTask.ToKey(),
+                        failedStatus,
+                        startResult,
+                        CancellationToken.None
+                    );
 
-                await _eventPublisher.PublishAsync(new SendNotificationResult(startResult), token);
+                    await _eventPublisher.PublishAsync(new SendNotificationResult(startResult), token);
+                }
             }
         }
         catch (Exception ex) when (ex is not OperationCanceledException)

--- a/src/Application/PlexDownloads/Execute/DownloadJob.cs
+++ b/src/Application/PlexDownloads/Execute/DownloadJob.cs
@@ -143,7 +143,7 @@ public class DownloadJob : IJob
                     await _commandExecutor.TryRefreshIfStaleIdAsync(
                         downloadTask.Id,
                         downloadTask.DownloadTaskType,
-                        startResult.ToResult(),
+                        startResult,
                         token
                     )
                 )

--- a/src/Application/PlexDownloads/Queue/DownloadQueue.cs
+++ b/src/Application/PlexDownloads/Queue/DownloadQueue.cs
@@ -199,6 +199,19 @@ public class DownloadQueue : IDownloadQueue
         if (queuedTask is not null)
             return Result.Ok(queuedTask);
 
+        // SourceUnavailable = Plex returned 404 on the stored part id. The auto-refresh path in
+        // DirectPlexDownloadClient already tries to recover before transitioning to this status,
+        // so by the time a task is here the refresh failed (library not re-synced, item gone from
+        // Plex, etc.). Re-attempt only after all real Queued work is exhausted so a long tail of
+        // broken tasks can't starve the queue; the standard retry cooldown stops a tight loop.
+        var sourceUnavailableTask = FindFirstLeafByStatus(
+            downloadTasks,
+            DownloadStatus.SourceUnavailable,
+            IsInRetryCooldown
+        );
+        if (sourceUnavailableTask is not null)
+            return Result.Ok(sourceUnavailableTask);
+
         return Result.Fail("There were no downloadTasks left to download.").LogDebug();
     }
 

--- a/src/Application/PlexDownloads/Queue/DownloadQueue.cs
+++ b/src/Application/PlexDownloads/Queue/DownloadQueue.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Threading.Channels;
 
 namespace Reaparr.Application;
@@ -7,12 +8,20 @@ namespace Reaparr.Application;
 /// </summary>
 public class DownloadQueue : IDownloadQueue
 {
+    /// <summary>
+    /// Cooldown applied to every download task after it is picked by the queue. Prevents the
+    /// queue picker from re-picking the same task in a tight loop when a download fails fast
+    /// (e.g. stale Plex part IDs returning 404 instantly).
+    /// </summary>
+    private static readonly TimeSpan RetryCooldown = TimeSpan.FromSeconds(60);
+
     private readonly ILogger _log;
     private readonly IReaparrDbContextFactory _dbContextFactory;
     private readonly IDownloadTaskScheduler _downloadTaskScheduler;
     private readonly IDownloadTaskUpdateDispatcher _downloadTaskUpdateDispatcher;
 
     private readonly Channel<int> _plexServersToCheckChannel = Channel.CreateUnbounded<int>();
+    private readonly ConcurrentDictionary<Guid, DateTime> _retryCooldownUntil = new();
 
     private readonly CancellationToken _token = new();
 
@@ -162,10 +171,14 @@ public class DownloadQueue : IDownloadQueue
                 nextDownloadTask.FullTitle
             );
 
+        _retryCooldownUntil[nextDownloadTask.Id] = DateTime.UtcNow + RetryCooldown;
         await _downloadTaskScheduler.StartDownloadTaskJob(nextDownloadTask.ToKey());
 
         return Result.Ok(nextDownloadTask);
     }
+
+    private bool IsInRetryCooldown(DownloadTaskGeneric task) =>
+        _retryCooldownUntil.TryGetValue(task.Id, out var until) && DateTime.UtcNow < until;
 
     /// <summary>
     /// Determines the next downloadable <see cref="DownloadTaskGeneric"/> to be executed.
@@ -178,11 +191,11 @@ public class DownloadQueue : IDownloadQueue
         if (downloadingTask is not null)
             return Result.Fail("There is already a downloadTask downloading.").LogDebug();
 
-        var serverUnreachableTask = FindFirstLeafByStatus(downloadTasks, DownloadStatus.ServerUnreachable);
+        var serverUnreachableTask = FindFirstLeafByStatus(downloadTasks, DownloadStatus.ServerUnreachable, IsInRetryCooldown);
         if (serverUnreachableTask is not null)
             return Result.Ok(serverUnreachableTask);
 
-        var queuedTask = FindFirstLeafByStatus(downloadTasks, DownloadStatus.Queued);
+        var queuedTask = FindFirstLeafByStatus(downloadTasks, DownloadStatus.Queued, IsInRetryCooldown);
         if (queuedTask is not null)
             return Result.Ok(queuedTask);
 
@@ -191,21 +204,22 @@ public class DownloadQueue : IDownloadQueue
 
     private static DownloadTaskGeneric? FindFirstLeafByStatus(
         IEnumerable<DownloadTaskGeneric> downloadTasks,
-        DownloadStatus status
+        DownloadStatus status,
+        Func<DownloadTaskGeneric, bool>? skip = null
     )
     {
         foreach (var downloadTask in downloadTasks)
         {
             if (downloadTask.Children.Any())
             {
-                var childTask = FindFirstLeafByStatus(downloadTask.Children, status);
+                var childTask = FindFirstLeafByStatus(downloadTask.Children, status, skip);
                 if (childTask is not null)
                     return childTask;
 
                 continue;
             }
 
-            if (downloadTask.DownloadStatus == status)
+            if (downloadTask.DownloadStatus == status && (skip is null || !skip(downloadTask)))
                 return downloadTask;
         }
 
@@ -288,6 +302,13 @@ public class DownloadQueue : IDownloadQueue
                     DownloadStatus.Downloading
                 );
         }
+
+        // Kick the queue for every Plex server. Without this, servers that were already online
+        // before the restart never fire ServerOnlineStatusChangedNotification (it only fires on
+        // transitions), so their queue picker is never invoked and they sit idle until the next
+        // status-check tick or external trigger.
+        if (plexServerIds.Any())
+            await CheckDownloadQueue(plexServerIds);
 
         return Result.Ok();
     }

--- a/src/Application/PlexDownloads/Queue/DownloadQueue.cs
+++ b/src/Application/PlexDownloads/Queue/DownloadQueue.cs
@@ -10,6 +10,7 @@ public class DownloadQueue : IDownloadQueue
     private readonly ILogger _log;
     private readonly IReaparrDbContextFactory _dbContextFactory;
     private readonly IDownloadTaskScheduler _downloadTaskScheduler;
+    private readonly IDownloadTaskUpdateDispatcher _downloadTaskUpdateDispatcher;
 
     private readonly Channel<int> _plexServersToCheckChannel = Channel.CreateUnbounded<int>();
 
@@ -18,12 +19,14 @@ public class DownloadQueue : IDownloadQueue
     public DownloadQueue(
         ILogger log,
         IReaparrDbContextFactory dbContextFactory,
-        IDownloadTaskScheduler downloadTaskScheduler
+        IDownloadTaskScheduler downloadTaskScheduler,
+        IDownloadTaskUpdateDispatcher downloadTaskUpdateDispatcher
     )
     {
         _log = log.ForContext<DownloadQueue>();
         _dbContextFactory = dbContextFactory;
         _downloadTaskScheduler = downloadTaskScheduler;
+        _downloadTaskUpdateDispatcher = downloadTaskUpdateDispatcher;
     }
 
     public bool IsBusy => _plexServersToCheckChannel.Reader.Count > 0;
@@ -98,12 +101,40 @@ public class DownloadQueue : IDownloadQueue
 
         var hasDownloadingTask = downloadTasks.Any(x => x.DownloadStatus == DownloadStatus.Downloading);
 
-        // This avoids race condition where job is finishing but still registered in Quartz
-        if (hasDownloadingTask && await _downloadTaskScheduler.IsServerDownloading(plexServerId))
+        if (hasDownloadingTask)
         {
-            return Result
-                .Fail("Cannot select the next download task because server is already downloading one.")
-                .LogWarning();
+            var isServerDownloading = await _downloadTaskScheduler.IsServerDownloading(plexServerId);
+            if (isServerDownloading)
+            {
+                // Real, active download in flight. Avoids race condition where job is finishing
+                // but still registered in Quartz.
+                return Result
+                    .Fail("Cannot select the next download task because server is already downloading one.")
+                    .LogWarning();
+            }
+
+            // Zombie: DB says Downloading but no Quartz job is running for it. This happens when
+            // the process is killed mid-download (OOM, container restart) so the DownloadFileCompleted
+            // handler never fires. Reset zombies to Queued so the picker can re-launch from the saved
+            // snapshot, then re-read the task list.
+            var zombies = FindAllLeavesByStatus(downloadTasks, DownloadStatus.Downloading);
+            foreach (var zombie in zombies)
+            {
+                _log.Here()
+                    .Warning(
+                        "Resetting zombie {DownloadStatus} task {DownloadTaskId} ({FullTitle}) on PlexServer {PlexServerName} — no scheduler job is running for it",
+                        DownloadStatus.Downloading,
+                        zombie.Id,
+                        zombie.FullTitle,
+                        plexServerName
+                    );
+                await _downloadTaskUpdateDispatcher.OnStatusChangedAsync(
+                    zombie.ToKey(),
+                    DownloadStatus.Queued,
+                    _token
+                );
+            }
+            downloadTasks = await dbContext.GetAllDownloadTasksByServerAsync(plexServerId, cancellationToken: _token);
         }
 
         _log.Here()
@@ -179,6 +210,86 @@ public class DownloadQueue : IDownloadQueue
         }
 
         return null;
+    }
+
+    private static List<DownloadTaskGeneric> FindAllLeavesByStatus(
+        IEnumerable<DownloadTaskGeneric> downloadTasks,
+        DownloadStatus status
+    )
+    {
+        var matches = new List<DownloadTaskGeneric>();
+        CollectLeavesByStatus(downloadTasks, status, matches);
+        return matches;
+    }
+
+    private static void CollectLeavesByStatus(
+        IEnumerable<DownloadTaskGeneric> downloadTasks,
+        DownloadStatus status,
+        List<DownloadTaskGeneric> matches
+    )
+    {
+        foreach (var downloadTask in downloadTasks)
+        {
+            if (downloadTask.Children.Any())
+            {
+                CollectLeavesByStatus(downloadTask.Children, status, matches);
+                continue;
+            }
+
+            if (downloadTask.DownloadStatus == status)
+                matches.Add(downloadTask);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<Result> RecoverInterruptedDownloadsAsync(CancellationToken cancellationToken = default)
+    {
+        using var dbContext = await _dbContextFactory.CreateAsync();
+
+        var plexServerIds = await dbContext.PlexServers
+            .AsNoTracking()
+            .Select(x => x.Id)
+            .ToListAsync(cancellationToken);
+
+        var totalReset = 0;
+        foreach (var plexServerId in plexServerIds)
+        {
+            var downloadTasks = await dbContext.GetAllDownloadTasksByServerAsync(
+                plexServerId,
+                cancellationToken: cancellationToken
+            );
+            var zombies = FindAllLeavesByStatus(downloadTasks, DownloadStatus.Downloading);
+            foreach (var zombie in zombies)
+            {
+                _log.Here()
+                    .Warning(
+                        "Recovering interrupted download task {DownloadTaskId} ({FullTitle}) on PlexServer {PlexServerId} — was left in {DownloadStatus} across a restart, resetting to {ResetStatus}",
+                        zombie.Id,
+                        zombie.FullTitle,
+                        plexServerId,
+                        DownloadStatus.Downloading,
+                        DownloadStatus.Queued
+                    );
+                await _downloadTaskUpdateDispatcher.OnStatusChangedAsync(
+                    zombie.ToKey(),
+                    DownloadStatus.Queued,
+                    cancellationToken
+                );
+                totalReset++;
+            }
+        }
+
+        if (totalReset > 0)
+        {
+            _log.Here()
+                .Information(
+                    "Recovered {Count} interrupted download task(s) left in {DownloadStatus} from a previous run",
+                    totalReset,
+                    DownloadStatus.Downloading
+                );
+        }
+
+        return Result.Ok();
     }
 
     private async Task ExecuteDownloadQueueCheck()

--- a/src/Application/PlexDownloads/RefreshMetadata/RefreshDownloadTaskMetadataCommand.cs
+++ b/src/Application/PlexDownloads/RefreshMetadata/RefreshDownloadTaskMetadataCommand.cs
@@ -1,0 +1,318 @@
+using System.Collections.Concurrent;
+using System.Text.RegularExpressions;
+
+namespace Reaparr.Application;
+
+/// <summary>
+/// Refresh a single download task's Plex identifiers (RatingKey / MediaId / PartId / FileLocationUrl)
+/// against the currently-synced library data. Used to recover from stale identifiers when the source
+/// Plex server has been re-scanned and the task's previously-cached IDs no longer resolve. Returns
+/// <c>true</c> if the task was updated, <c>false</c> if no change was needed or possible.
+/// </summary>
+public record RefreshDownloadTaskMetadataCommand(Guid DownloadTaskFileId, DownloadTaskType TaskType)
+    : ICommand<Result<bool>>;
+
+public class RefreshDownloadTaskMetadataCommandValidator : AbstractValidator<RefreshDownloadTaskMetadataCommand>
+{
+    public RefreshDownloadTaskMetadataCommandValidator()
+    {
+        RuleFor(x => x.DownloadTaskFileId).NotEqual(Guid.Empty);
+        RuleFor(x => x.TaskType)
+            .Must(t => t == DownloadTaskType.EpisodeData || t == DownloadTaskType.MovieData)
+            .WithMessage("Only EpisodeData and MovieData tasks can be refreshed.");
+    }
+}
+
+public class RefreshDownloadTaskMetadataCommandHandler
+    : ICommandHandler<RefreshDownloadTaskMetadataCommand, Result<bool>>
+{
+    /// <summary>
+    /// Suppress repeated refresh attempts for the same task within this window. Refreshing is
+    /// cheap (one indexed lookup) but Quartz could otherwise re-fire the queue picker for the
+    /// same broken task many times per minute and produce noisy log churn.
+    /// </summary>
+    internal static readonly TimeSpan RefreshCooldown = TimeSpan.FromMinutes(15);
+
+    // S03E15, S03.E15, S 03 E 15, etc.
+    private static readonly Regex SeRegexCombined = new(
+        @"[Ss](\d{1,3})[._\s]?[Ee](\d{1,3})",
+        RegexOptions.Compiled
+    );
+
+    // 23x01 — used by some Top Gear releases.
+    private static readonly Regex SeRegexXShort = new(@"\b(\d{1,3})x(\d{1,3})\b", RegexOptions.Compiled);
+
+    // Season number from a path segment like ".../Season 2/...".
+    private static readonly Regex SeasonPathRegex = new(@"Season\s+(\d{1,3})", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    // Episode-only fallback when only the season was on the path.
+    private static readonly Regex EpisodeOnlyRegex = new(
+        @"\b(?:E|EP|Episode)[._\s]?(\d{1,3})\b",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled
+    );
+
+    internal static readonly ConcurrentDictionary<Guid, DateTime> _lastRefreshAt = new();
+
+    private readonly ILogger _log;
+    private readonly IReaparrDbContextFactory _dbContextFactory;
+
+    public RefreshDownloadTaskMetadataCommandHandler(ILogger log, IReaparrDbContextFactory dbContextFactory)
+    {
+        _log = log.ForContext<RefreshDownloadTaskMetadataCommandHandler>();
+        _dbContextFactory = dbContextFactory;
+    }
+
+    public async Task<Result<bool>> ExecuteAsync(
+        RefreshDownloadTaskMetadataCommand command,
+        CancellationToken cancellationToken
+    )
+    {
+        if (
+            _lastRefreshAt.TryGetValue(command.DownloadTaskFileId, out var last)
+            && DateTime.UtcNow - last < RefreshCooldown
+        )
+        {
+            return Result.Ok(false);
+        }
+
+        _lastRefreshAt[command.DownloadTaskFileId] = DateTime.UtcNow;
+
+        return command.TaskType switch
+        {
+            DownloadTaskType.EpisodeData => await RefreshEpisodeAsync(command.DownloadTaskFileId, cancellationToken),
+            DownloadTaskType.MovieData => await RefreshMovieAsync(command.DownloadTaskFileId, cancellationToken),
+            _ => Result.Ok(false),
+        };
+    }
+
+    private async Task<Result<bool>> RefreshEpisodeAsync(Guid taskId, CancellationToken ct)
+    {
+        using var dbContext = await _dbContextFactory.CreateAsync();
+
+        // Load the file + parent show context. AsNoTracking because we apply changes via ExecuteUpdate.
+        var task = await dbContext
+            .DownloadTaskTvShowEpisodeFile.AsNoTracking()
+            .Where(f => f.Id == taskId)
+            .Select(f => new
+            {
+                f.Id,
+                f.PlexServerId,
+                f.PlexLibraryId,
+                f.Quality,
+                f.PlexApiRatingKey,
+                f.PlexApiMediaId,
+                f.PlexApiPartId,
+                f.FileLocationUrl,
+                f.FullTitle,
+                ShowTitle = f.Parent!.Parent!.Parent!.Title,
+                ShowYear = f.Parent!.Parent!.Parent!.Year,
+            })
+            .FirstOrDefaultAsync(ct);
+
+        if (task is null)
+            return Result.Ok(false);
+
+        var parsed = ParseSeasonEpisode(task.FullTitle);
+        if (parsed is null)
+        {
+            _log.Here()
+                .Warning(
+                    "Refresh skipped — could not parse season/episode from FullTitle: {FullTitle}",
+                    task.FullTitle
+                );
+            return Result.Ok(false);
+        }
+        var (seasonNumber, episodeNumber) = parsed.Value;
+
+        // Match the freshly-synced library data. Prefer same Quality, fall back to highest available.
+        var candidates = await (
+            from ed in dbContext.PlexTvShowEpisodeData.AsNoTracking()
+            join e in dbContext.PlexTvShowEpisodes on ed.PlexTvShowEpisodeId equals e.Id
+            join s in dbContext.PlexTvShowSeason on e.TvShowSeasonId equals s.Id
+            join sh in dbContext.PlexTvShows on s.TvShowId equals sh.Id
+            where sh.PlexServerId == task.PlexServerId
+                && sh.PlexLibraryId == task.PlexLibraryId
+                && sh.Title == task.ShowTitle
+                && sh.Year == task.ShowYear
+                && s.SeasonNumber == seasonNumber
+                && e.EpisodeNumber == episodeNumber
+            select new
+            {
+                ed.PlexApiRatingKey,
+                ed.PlexApiMediaId,
+                ed.PlexApiPartId,
+                ed.Key,
+                ed.Quality,
+            }
+        ).ToListAsync(ct);
+
+        if (candidates.Count == 0)
+            return Result.Ok(false);
+
+        var picked =
+            candidates.FirstOrDefault(c => c.Quality == task.Quality)
+            ?? candidates.OrderByDescending(c => c.Quality).First();
+
+        if (
+            picked.PlexApiRatingKey == task.PlexApiRatingKey
+            && picked.PlexApiMediaId == task.PlexApiMediaId
+            && picked.PlexApiPartId == task.PlexApiPartId
+        )
+        {
+            // Already current — no work to do.
+            return Result.Ok(false);
+        }
+
+        var updatedRows = await dbContext
+            .DownloadTaskTvShowEpisodeFile.Where(f => f.Id == taskId)
+            .ExecuteUpdateAsync(
+                setters =>
+                    setters
+                        .SetProperty(f => f.PlexApiRatingKey, picked.PlexApiRatingKey)
+                        .SetProperty(f => f.PlexApiMediaId, picked.PlexApiMediaId)
+                        .SetProperty(f => f.PlexApiPartId, picked.PlexApiPartId)
+                        .SetProperty(f => f.FileLocationUrl, picked.Key)
+                        .SetProperty(f => f.DataReceived, 0L)
+                        .SetProperty(f => f.DirectDownloadSnapshot, (DirectDownloadSnapshot?)null)
+                        .SetProperty(f => f.Percentage, 0m)
+                        .SetProperty(f => f.TimeRemaining, 0),
+                ct
+            );
+
+        if (updatedRows == 0)
+            return Result.Ok(false);
+
+        _log.Here()
+            .Information(
+                "Refreshed metadata for episode task {FullTitle} on server {PlexServerId}: "
+                    + "rating {OldRating}->{NewRating}, media {OldMedia}->{NewMedia}, part {OldPart}->{NewPart}",
+                task.FullTitle,
+                task.PlexServerId,
+                task.PlexApiRatingKey,
+                picked.PlexApiRatingKey,
+                task.PlexApiMediaId,
+                picked.PlexApiMediaId,
+                task.PlexApiPartId,
+                picked.PlexApiPartId
+            );
+        return Result.Ok(true);
+    }
+
+    private async Task<Result<bool>> RefreshMovieAsync(Guid taskId, CancellationToken ct)
+    {
+        using var dbContext = await _dbContextFactory.CreateAsync();
+
+        var task = await dbContext
+            .DownloadTaskMovieFile.AsNoTracking()
+            .Where(f => f.Id == taskId)
+            .Select(f => new
+            {
+                f.Id,
+                f.PlexServerId,
+                f.PlexLibraryId,
+                f.Quality,
+                f.PlexApiRatingKey,
+                f.PlexApiMediaId,
+                f.PlexApiPartId,
+                f.FileLocationUrl,
+                f.FullTitle,
+                MovieTitle = f.Parent!.Title,
+                MovieYear = f.Parent!.Year,
+            })
+            .FirstOrDefaultAsync(ct);
+
+        if (task is null)
+            return Result.Ok(false);
+
+        var candidates = await (
+            from md in dbContext.PlexMovieData.AsNoTracking()
+            join m in dbContext.PlexMovies on md.PlexMovieId equals m.Id
+            where m.PlexServerId == task.PlexServerId
+                && m.PlexLibraryId == task.PlexLibraryId
+                && m.Title == task.MovieTitle
+                && m.Year == task.MovieYear
+            select new
+            {
+                md.PlexApiRatingKey,
+                md.PlexApiMediaId,
+                md.PlexApiPartId,
+                md.Key,
+                md.Quality,
+            }
+        ).ToListAsync(ct);
+
+        if (candidates.Count == 0)
+            return Result.Ok(false);
+
+        var picked =
+            candidates.FirstOrDefault(c => c.Quality == task.Quality)
+            ?? candidates.OrderByDescending(c => c.Quality).First();
+
+        if (
+            picked.PlexApiRatingKey == task.PlexApiRatingKey
+            && picked.PlexApiMediaId == task.PlexApiMediaId
+            && picked.PlexApiPartId == task.PlexApiPartId
+        )
+        {
+            return Result.Ok(false);
+        }
+
+        var updatedRows = await dbContext
+            .DownloadTaskMovieFile.Where(f => f.Id == taskId)
+            .ExecuteUpdateAsync(
+                setters =>
+                    setters
+                        .SetProperty(f => f.PlexApiRatingKey, picked.PlexApiRatingKey)
+                        .SetProperty(f => f.PlexApiMediaId, picked.PlexApiMediaId)
+                        .SetProperty(f => f.PlexApiPartId, picked.PlexApiPartId)
+                        .SetProperty(f => f.FileLocationUrl, picked.Key)
+                        .SetProperty(f => f.DataReceived, 0L)
+                        .SetProperty(f => f.DirectDownloadSnapshot, (DirectDownloadSnapshot?)null)
+                        .SetProperty(f => f.Percentage, 0m)
+                        .SetProperty(f => f.TimeRemaining, 0),
+                ct
+            );
+
+        if (updatedRows == 0)
+            return Result.Ok(false);
+
+        _log.Here()
+            .Information(
+                "Refreshed metadata for movie task {FullTitle} on server {PlexServerId}: "
+                    + "rating {OldRating}->{NewRating}, media {OldMedia}->{NewMedia}, part {OldPart}->{NewPart}",
+                task.FullTitle,
+                task.PlexServerId,
+                task.PlexApiRatingKey,
+                picked.PlexApiRatingKey,
+                task.PlexApiMediaId,
+                picked.PlexApiMediaId,
+                task.PlexApiPartId,
+                picked.PlexApiPartId
+            );
+        return Result.Ok(true);
+    }
+
+    internal static (int Season, int Episode)? ParseSeasonEpisode(string fullTitle)
+    {
+        var combined = SeRegexCombined.Match(fullTitle);
+        if (combined.Success)
+            return (int.Parse(combined.Groups[1].Value), int.Parse(combined.Groups[2].Value));
+
+        var xShort = SeRegexXShort.Match(fullTitle);
+        if (xShort.Success)
+            return (int.Parse(xShort.Groups[1].Value), int.Parse(xShort.Groups[2].Value));
+
+        var seasonPath = SeasonPathRegex.Match(fullTitle);
+        if (seasonPath.Success)
+        {
+            var parts = fullTitle.Split('/');
+            var filename = parts.Length > 0 ? parts[^1] : fullTitle;
+            var episode = EpisodeOnlyRegex.Match(filename);
+            if (episode.Success)
+                return (int.Parse(seasonPath.Groups[1].Value), int.Parse(episode.Groups[1].Value));
+        }
+
+        return null;
+    }
+
+}

--- a/src/Application/PlexDownloads/RefreshMetadata/RefreshDownloadTaskMetadataCommand.cs
+++ b/src/Application/PlexDownloads/RefreshMetadata/RefreshDownloadTaskMetadataCommand.cs
@@ -12,6 +12,38 @@ namespace Reaparr.Application;
 public record RefreshDownloadTaskMetadataCommand(Guid DownloadTaskFileId, DownloadTaskType TaskType)
     : ICommand<Result<bool>>;
 
+/// <summary>
+/// Helpers for the "on 404, try refreshing the task's Plex IDs once before giving up" pattern,
+/// shared between every download client that surfaces a Plex 404 (Direct probe + post-download,
+/// Dash, and the DownloadJob fall-through). Returns <c>true</c> if the refresh succeeded and the
+/// caller should treat the task as recoverable; <c>false</c> means fall through to the existing
+/// failure handling.
+/// </summary>
+public static class DownloadTaskRefreshHelper
+{
+    public static async Task<bool> TryRefreshIfStaleIdAsync(
+        this ICommandExecutor commandExecutor,
+        Guid downloadTaskFileId,
+        DownloadTaskType taskType,
+        Result failureResult,
+        CancellationToken cancellationToken
+    )
+    {
+        if (!failureResult.Has404NotFoundError())
+            return false;
+
+        if (taskType is not DownloadTaskType.EpisodeData and not DownloadTaskType.MovieData)
+            return false;
+
+        var refreshResult = await commandExecutor.Send(
+            new RefreshDownloadTaskMetadataCommand(downloadTaskFileId, taskType),
+            cancellationToken
+        );
+
+        return refreshResult.IsSuccess && refreshResult.Value;
+    }
+}
+
 public class RefreshDownloadTaskMetadataCommandValidator : AbstractValidator<RefreshDownloadTaskMetadataCommand>
 {
     public RefreshDownloadTaskMetadataCommandValidator()
@@ -55,11 +87,17 @@ public class RefreshDownloadTaskMetadataCommandHandler
 
     private readonly ILogger _log;
     private readonly IReaparrDbContextFactory _dbContextFactory;
+    private readonly IDownloadQueue _downloadQueue;
 
-    public RefreshDownloadTaskMetadataCommandHandler(ILogger log, IReaparrDbContextFactory dbContextFactory)
+    public RefreshDownloadTaskMetadataCommandHandler(
+        ILogger log,
+        IReaparrDbContextFactory dbContextFactory,
+        IDownloadQueue downloadQueue
+    )
     {
         _log = log.ForContext<RefreshDownloadTaskMetadataCommandHandler>();
         _dbContextFactory = dbContextFactory;
+        _downloadQueue = downloadQueue;
     }
 
     public async Task<Result<bool>> ExecuteAsync(
@@ -195,6 +233,7 @@ public class RefreshDownloadTaskMetadataCommandHandler
                 task.PlexApiPartId,
                 picked.PlexApiPartId
             );
+        await _downloadQueue.CheckDownloadQueue([task.PlexServerId]);
         return Result.Ok(true);
     }
 
@@ -289,6 +328,7 @@ public class RefreshDownloadTaskMetadataCommandHandler
                 task.PlexApiPartId,
                 picked.PlexApiPartId
             );
+        await _downloadQueue.CheckDownloadQueue([task.PlexServerId]);
         return Result.Ok(true);
     }
 

--- a/tests/UnitTests/Application.UnitTests/PlexDownloads/DownloadQueue/DownloadQueue_CheckDownloadQueueServer_UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexDownloads/DownloadQueue/DownloadQueue_CheckDownloadQueueServer_UnitTests.cs
@@ -63,7 +63,7 @@ public class DownloadQueueCheckDownloadQueueUnitTests : BaseUnitTest<DownloadQue
     }
 
     [Test]
-    public async Task ShouldHaveNoStartCommands_WhenATaskIsAlreadyDownloading()
+    public async Task ShouldResetZombieAndStartNextTask_WhenDownloadingStatusButSchedulerHasNoJob()
     {
         // Arrange
         await SetupDatabase(
@@ -83,21 +83,45 @@ public class DownloadQueueCheckDownloadQueueUnitTests : BaseUnitTest<DownloadQue
             .Where(x => x.PlexServerId == 1)
             .IncludeAll()
             .ToListAsync(CancellationToken);
-        Mock.Mock<IDownloadTaskScheduler>().Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>())).ReturnOk();
-        Mock.Mock<IDownloadTaskScheduler>().Setup(x => x.IsServerDownloading(It.IsAny<int>())).ReturnsAsync(false);
-
         var startedDownloadTask = downloadTasks[0];
         startedDownloadTask.SetDownloadStatus(DownloadStatus.Downloading);
         await dbContext.SaveChangesAsync(CancellationToken);
+        var zombieLeafId = startedDownloadTask.Children.First().Id;
+
+        // The dispatcher writes status to the same in-memory database so the queue picker sees
+        // the reconciled state on its re-read.
+        Mock.Mock<IDownloadTaskScheduler>().Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>())).ReturnOk();
+        Mock.Mock<IDownloadTaskScheduler>().Setup(x => x.IsServerDownloading(It.IsAny<int>())).ReturnsAsync(false);
+        Mock.Mock<IDownloadTaskUpdateDispatcher>()
+            .Setup(x =>
+                x.OnStatusChangedAsync(It.IsAny<DownloadTaskKey>(), It.IsAny<DownloadStatus>(), It.IsAny<CancellationToken>())
+            )
+            .Callback<DownloadTaskKey, DownloadStatus, CancellationToken>(
+                (key, status, _) =>
+                {
+                    using var ctx = Mock.Container.Resolve<IReaparrDbContext>();
+                    ctx.SetDownloadStatus(key, status).GetAwaiter().GetResult();
+                }
+            )
+            .Returns(Task.CompletedTask);
 
         // Act
         var result = await Sut.CheckDownloadQueueServer(1);
 
         // Assert
         result.IsSuccess.ShouldBeTrue();
-        result.Value.ShouldBeNull();
+        result.Value.ShouldNotBeNull();
+        Mock.Mock<IDownloadTaskUpdateDispatcher>()
+            .Verify(
+                x => x.OnStatusChangedAsync(
+                    It.Is<DownloadTaskKey>(k => k.Id == zombieLeafId),
+                    DownloadStatus.Queued,
+                    It.IsAny<CancellationToken>()
+                ),
+                Times.Once()
+            );
         Mock.Mock<IDownloadTaskScheduler>()
-            .Verify(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>()), Times.Never());
+            .Verify(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>()), Times.Once());
     }
 
     [Test]

--- a/tests/UnitTests/Application.UnitTests/PlexDownloads/DownloadQueue/DownloadQueue_GetNextDownloadTask_UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexDownloads/DownloadQueue/DownloadQueue_GetNextDownloadTask_UnitTests.cs
@@ -266,4 +266,40 @@ public class DownloadQueueGetNextDownloadTaskUnitTests : BaseUnitTest<DownloadQu
         var nextDownloadTaskId = downloadTasks[4].Children[0].Id;
         nextDownloadTask.Value.Id.ShouldBe(nextDownloadTaskId);
     }
+
+    [Test]
+    public async Task ShouldPickSourceUnavailable_OnlyWhenNoOtherWorkIsAvailable()
+    {
+        // Arrange — one SourceUnavailable and one Queued task.
+        await SetupDatabase(81905, config => config.MovieDownloadTasksCount = 2);
+
+        var downloadTasks = await IDbContext.GetAllDownloadTasksByServerAsync(
+            asTracking: true,
+            cancellationToken: CancellationToken
+        );
+
+        var sourceUnavailableTask = downloadTasks[0].Children[0];
+        sourceUnavailableTask.SetDownloadStatus(DownloadStatus.SourceUnavailable);
+        downloadTasks[0].SetDownloadStatus(DownloadStatus.SourceUnavailable);
+
+        var queuedTask = downloadTasks[1].Children[0];
+        queuedTask.SetDownloadStatus(DownloadStatus.Queued);
+        downloadTasks[1].SetDownloadStatus(DownloadStatus.Queued);
+
+        await IDbContext.SaveChangesAsync(CancellationToken);
+
+        // Act — Queued must be picked first; SourceUnavailable falls to last priority.
+        var first = Sut.GetNextDownloadTask(downloadTasks);
+        first.IsSuccess.ShouldBeTrue();
+        first.Value.Id.ShouldBe(queuedTask.Id);
+
+        // Re-mark the queued task as Completed so only SourceUnavailable remains.
+        queuedTask.SetDownloadStatus(DownloadStatus.Completed);
+        downloadTasks[1].SetDownloadStatus(DownloadStatus.Completed);
+        await IDbContext.SaveChangesAsync(CancellationToken);
+
+        var second = Sut.GetNextDownloadTask(downloadTasks);
+        second.IsSuccess.ShouldBeTrue();
+        second.Value.Id.ShouldBe(sourceUnavailableTask.Id);
+    }
 }

--- a/tests/UnitTests/Application.UnitTests/PlexDownloads/DownloadQueue/DownloadQueue_RecoverInterruptedDownloads_UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexDownloads/DownloadQueue/DownloadQueue_RecoverInterruptedDownloads_UnitTests.cs
@@ -1,0 +1,86 @@
+namespace Reaparr.Application.UnitTests;
+
+public class DownloadQueueRecoverInterruptedDownloadsUnitTests : BaseUnitTest<DownloadQueue>
+{
+    [Test]
+    public async Task ShouldResetDownloadingLeavesToQueued_WhenSomeAreLeftInDownloadingFromAPreviousRun()
+    {
+        // Arrange
+        await SetupDatabase(
+            41207,
+            config =>
+            {
+                config.PlexServerCount = 1;
+                config.PlexMovieLibraryCount = 1;
+                config.MovieCount = 4;
+                config.MovieDownloadTasksCount = 3;
+            }
+        );
+
+        var dbContext = IDbContext;
+        var downloadTasks = await dbContext
+            .DownloadTaskMovie.AsTracking()
+            .Where(x => x.PlexServerId == 1)
+            .IncludeAll()
+            .ToListAsync(CancellationToken);
+        downloadTasks[0].SetDownloadStatus(DownloadStatus.Downloading);
+        downloadTasks[1].SetDownloadStatus(DownloadStatus.Downloading);
+        await dbContext.SaveChangesAsync(CancellationToken);
+        var zombieLeafIds = new[]
+        {
+            downloadTasks[0].Children.First().Id,
+            downloadTasks[1].Children.First().Id,
+        };
+
+        Mock.Mock<IDownloadTaskUpdateDispatcher>()
+            .Setup(x =>
+                x.OnStatusChangedAsync(It.IsAny<DownloadTaskKey>(), It.IsAny<DownloadStatus>(), It.IsAny<CancellationToken>())
+            )
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var result = await Sut.RecoverInterruptedDownloadsAsync(CancellationToken);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        foreach (var zombieLeafId in zombieLeafIds)
+        {
+            Mock.Mock<IDownloadTaskUpdateDispatcher>()
+                .Verify(
+                    x => x.OnStatusChangedAsync(
+                        It.Is<DownloadTaskKey>(k => k.Id == zombieLeafId),
+                        DownloadStatus.Queued,
+                        It.IsAny<CancellationToken>()
+                    ),
+                    Times.Once()
+                );
+        }
+    }
+
+    [Test]
+    public async Task ShouldDoNothing_WhenNoTasksAreInDownloadingStatus()
+    {
+        // Arrange
+        await SetupDatabase(
+            41208,
+            config =>
+            {
+                config.PlexServerCount = 1;
+                config.PlexMovieLibraryCount = 1;
+                config.MovieCount = 3;
+                config.MovieDownloadTasksCount = 3;
+            }
+        );
+
+        // Act
+        var result = await Sut.RecoverInterruptedDownloadsAsync(CancellationToken);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        Mock.Mock<IDownloadTaskUpdateDispatcher>()
+            .Verify(
+                x => x.OnStatusChangedAsync(It.IsAny<DownloadTaskKey>(), It.IsAny<DownloadStatus>(), It.IsAny<CancellationToken>()),
+                Times.Never()
+            );
+    }
+}

--- a/tests/UnitTests/Application.UnitTests/PlexDownloads/DownloadQueue/DownloadQueue_RetryCooldown_UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexDownloads/DownloadQueue/DownloadQueue_RetryCooldown_UnitTests.cs
@@ -1,0 +1,36 @@
+namespace Reaparr.Application.UnitTests;
+
+public class DownloadQueueRetryCooldownUnitTests : BaseUnitTest<DownloadQueue>
+{
+    [Test]
+    public async Task ShouldSkipRecentlyAttemptedTask_AndPickAnotherInsteadOnRapidReentry()
+    {
+        // Arrange
+        await SetupDatabase(
+            58119,
+            config =>
+            {
+                config.PlexServerCount = 1;
+                config.PlexMovieLibraryCount = 1;
+                config.MovieCount = 3;
+                config.MovieDownloadTasksCount = 3;
+            }
+        );
+
+        Mock.Mock<IDownloadTaskScheduler>().Setup(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>())).ReturnOk();
+        Mock.Mock<IDownloadTaskScheduler>().Setup(x => x.IsServerDownloading(It.IsAny<int>())).ReturnsAsync(false);
+
+        // Act
+        var firstPick = await Sut.CheckDownloadQueueServer(1);
+        var secondPick = await Sut.CheckDownloadQueueServer(1);
+
+        // Assert
+        firstPick.IsSuccess.ShouldBeTrue();
+        firstPick.Value.ShouldNotBeNull();
+        secondPick.IsSuccess.ShouldBeTrue();
+        secondPick.Value.ShouldNotBeNull();
+        secondPick.Value.Id.ShouldNotBe(firstPick.Value.Id);
+        Mock.Mock<IDownloadTaskScheduler>()
+            .Verify(x => x.StartDownloadTaskJob(It.IsAny<DownloadTaskKey>()), Times.Exactly(2));
+    }
+}

--- a/tests/UnitTests/Application.UnitTests/PlexDownloads/RefreshMetadata/RefreshDownloadTaskMetadataCommandHandler.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexDownloads/RefreshMetadata/RefreshDownloadTaskMetadataCommandHandler.UnitTests.cs
@@ -1,0 +1,82 @@
+namespace Reaparr.Application.UnitTests;
+
+public class RefreshDownloadTaskMetadataCommandHandlerUnitTests
+    : BaseUnitTest<RefreshDownloadTaskMetadataCommandHandler>
+{
+    [Test]
+    [Arguments("Top.Gear.(2002).S22E04.mkv", 22, 4)]
+    [Arguments("The X-Files.S03.E15 - Piper Maru.mkv", 3, 15)]
+    [Arguments("top_gear.23x01.720p_hdtv_x264-fov.mkv", 23, 1)]
+    [Arguments("The Sopranos/Season 2/The Happy Wanderer/The.Sopranos.S02E06.mkv", 2, 6)]
+    [Arguments("Show/Season 5/Episode 03.mkv", 5, 3)]
+    public void ShouldParseSeasonEpisode_FromCommonFilenamePatterns(string fullTitle, int season, int episode)
+    {
+        var parsed = RefreshDownloadTaskMetadataCommandHandler.ParseSeasonEpisode(fullTitle);
+        parsed.ShouldNotBeNull();
+        parsed.Value.Season.ShouldBe(season);
+        parsed.Value.Episode.ShouldBe(episode);
+    }
+
+    [Test]
+    public async Task ShouldRespectCooldown_OnRepeatedRefreshAttempts()
+    {
+        // Arrange — clear the static dict so this test is deterministic.
+        RefreshDownloadTaskMetadataCommandHandler._lastRefreshAt.Clear();
+        await SetupDatabase(76001, config =>
+        {
+            config.PlexServerCount = 1;
+            config.PlexMovieLibraryCount = 1;
+            config.MovieCount = 1;
+            config.MovieDownloadTasksCount = 1;
+        });
+
+        var taskId = (await IDbContext.DownloadTaskMovieFile.AsNoTracking().FirstAsync(CancellationToken)).Id;
+
+        // Act — first call should run; second within cooldown should short-circuit.
+        var first = await Sut.ExecuteAsync(
+            new RefreshDownloadTaskMetadataCommand(taskId, DownloadTaskType.MovieData),
+            CancellationToken
+        );
+        var second = await Sut.ExecuteAsync(
+            new RefreshDownloadTaskMetadataCommand(taskId, DownloadTaskType.MovieData),
+            CancellationToken
+        );
+
+        // Assert — both succeed; both return false (no work because seeded data has matching IDs).
+        first.IsSuccess.ShouldBeTrue();
+        second.IsSuccess.ShouldBeTrue();
+        first.Value.ShouldBeFalse();
+        second.Value.ShouldBeFalse();
+        RefreshDownloadTaskMetadataCommandHandler._lastRefreshAt.ContainsKey(taskId).ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task ShouldReturnFalse_WhenTaskNotFound()
+    {
+        RefreshDownloadTaskMetadataCommandHandler._lastRefreshAt.Clear();
+        await SetupDatabase(76002);
+
+        var result = await Sut.ExecuteAsync(
+            new RefreshDownloadTaskMetadataCommand(Guid.NewGuid(), DownloadTaskType.MovieData),
+            CancellationToken
+        );
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task ShouldReturnFalse_WhenTaskTypeIsUnsupported()
+    {
+        RefreshDownloadTaskMetadataCommandHandler._lastRefreshAt.Clear();
+        await SetupDatabase(76003);
+
+        var result = await Sut.ExecuteAsync(
+            new RefreshDownloadTaskMetadataCommand(Guid.NewGuid(), DownloadTaskType.Season),
+            CancellationToken
+        );
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
## Problem

When a source Plex server is re-scanned (library rebuild, agent change, library refresh in maintenance mode), Plex re-assigns every `Media.Id` and `Part.Id`. Reaparr stores these identifiers on the download task at creation time and never re-resolves them. Any task created before a re-scan hits HTTP 404 forever, transitions to `SourceUnavailable` (or, today, falls through to generic `Error`), and the only recovery is for a user to delete + re-queue the task manually.

I just spent an afternoon writing a bespoke Python script to walk 580 broken tasks against a freshly-synced library and rewrite IDs by hand. That's the manual version of what this PR makes the queue do on its own.

## What this PR does

1. **`GetDirectDownloadUrlCommand` now attaches the HTTP status code to its failure `Result`** via `AddStatusCode(statusCode)`, so `Has404NotFoundError()` actually fires. Previously the failure was a plain `Result.Fail(string)` with no metadata, so every probe 404 fell through to the generic `Error` bucket regardless of the existing `Has404NotFoundError()` check downstream.

2. **New `RefreshDownloadTaskMetadataCommand`** under `src/Application/PlexDownloads/RefreshMetadata/`. Given a download-task file id and a `DownloadTaskType` (`EpisodeData` / `MovieData`), it parses season/episode from the task's `FullTitle` (supports `S03E15`, `S03.E15`, `01x02`, and `Season N/.../E12` filename conventions), looks up the matching row in the freshly-synced `PlexTvShowEpisodeData` / `PlexMovieData` tables by `(server, library, show/movie, year, season#, episode#)`, picks the entry whose `Quality` matches the task (falling back to highest quality), and — if any of the IDs differ — `ExecuteUpdate`s `PlexApiRatingKey` / `PlexApiMediaId` / `PlexApiPartId` / `FileLocationUrl` and resets the transfer-progress fields. A 15-min in-memory cooldown per task prevents tight refresh loops; on success it calls `IDownloadQueue.CheckDownloadQueue([serverId])` so the retry runs within seconds.

3. **`DownloadTaskRefreshHelper.TryRefreshIfStaleIdAsync(ICommandExecutor, ...)`** — a small extension that consolidates the \"on 404 → try refresh → fall through if no match\" pattern so it stays consistent across the four 404 sites.

4. **Hooked at every 404 site:**
   - `DirectPlexDownloadClient.Start()` — URL probe failure
   - `DirectPlexDownloadClient` — mid-download error in the `DownloadFileCompleted` handler
   - `DashPlexDownloadClient.HandleDownloadCompleted` — dash-mpd-cli completion failure
   - `DownloadJob` — the Quartz-job fall-through after `Start()` returns
   On successful refresh, the task transitions to `Queued`; on failure (no match, refresh on cooldown, etc.), the existing failure handling runs unchanged.

5. **`DownloadQueue.GetNextDownloadTask` picks `SourceUnavailable` last** (after `Queued`). Before this PR the picker never re-attempted tasks in `SourceUnavailable`, so a 404 was effectively a permanent failure. Now broken tasks still cycle (with the standard retry cooldown to prevent a tight loop), so if the user runs a `LibrarySync` later, the next pick will auto-refresh and succeed without manual intervention.

## Tests

- `RefreshDownloadTaskMetadataCommandHandlerUnitTests` — parser across all five filename patterns; cooldown short-circuits repeat refreshes; missing task returns `false`; unsupported task type returns `false`.
- `DownloadQueueGetNextDownloadTaskUnitTests.ShouldPickSourceUnavailable_OnlyWhenNoOtherWorkIsAvailable` — Queued beats SourceUnavailable; SourceUnavailable picked only when nothing else is left.

## Verified live

Deployed against my own private fork's image and observed the recovery flow firing on a real failed download on 2026-05-13:

```
RefreshDownloadTaskMetadataCommand.cs:279.RefreshMovieAsync()
  => Refreshed metadata for movie task Amadeus (1984) ... on server 4:
     rating 1657375->2227944, media 2172452->2970279, part 2188521->2986717
DirectPlexDownloadClient.cs:103.Start()
  => Auto-refreshed metadata for Amadeus (1984) DC (1080p x265 10bit Tigole).mkv;
     resetting status to Queued for retry
```

The task was downloading minutes later under the corrected URL.

## Dependency

Stacks on #586 (`feat/queue-resilience`) — the new `SourceUnavailable` bucket in the picker uses the `IsInRetryCooldown` predicate added there. Branch is `feat/queue-resilience` based; if #586 lands first this rebases cleanly onto `dev`. Test conflict resolved during the cherry-pick by dropping `feat/auto-retry` (#584) tests that I never authored.

## Out of scope

- No new \"refresh now\" UI button — the auto-refresh runs implicitly when a download attempts and fails. A manual trigger could be a follow-up.
- Doesn't try to recover when the entire show/movie has been deleted from Plex (no candidate row in the library) — those tasks legitimately need user intervention.
- Doesn't trigger a `LibrarySync` itself before refreshing — if the cached library is stale, the refresh fails. Reaparr's scheduled syncs eventually catch up and the next retry succeeds; a future PR could optionally fire a sync on first failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interrupted downloads are now recovered at startup
  * Automatic metadata refresh when downloads fail due to stale Plex identifiers
  * Added retry cooldown to prevent rapid repeated attempts of failing downloads

* **Bug Fixes**
  * Improved detection and recovery of zombie downloads (tasks marked as downloading but not actively running)
  * Enhanced error handling for source unavailability issues

* **Tests**
  * Added comprehensive unit tests for download recovery, retry cooldown, and metadata refresh functionality

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Reaparr/Reaparr/pull/587)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->