### PR TITLE
Hotfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,4 @@ config.json
 .agent-work
 
 .codex
+.playwright-mcp

--- a/.skillshare/skills/media-overview-cache/SKILL.md
+++ b/.skillshare/skills/media-overview-cache/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: media-overview-cache
+description: ALWAYS load when working on the Reaparr media overview cache system — includes MediaQueryCache, cache invalidation, warmup, GetAllMediaByTypeEndpoint, library sync/refresh commands that invalidate the cache, the mediaOverviewStore frontend, or the MediaOverview component. Covers the stale-while-revalidate pattern, dirty-mark invalidation, background rebuilds, 503-on-miss behavior, auto-retry, and the key structure.
+---
+
+# Media Overview Cache
+
+## When to load this skill
+
+Load this skill for **any** work touching:
+
+- `src/Data/Cache/MediaQueryCache.cs` — the cache singleton
+- `src/Data.Contracts/Cache/IMediaQueryCache.cs` — the cache interface
+- `src/Data/Cache/DTO/MediaQueryMetadataKey.cs` or `MediaQuerySortedListKey.cs` — cache keys
+- `src/Application/PlexMedia/GetAll/GetAllMediaByTypeEndpoint.cs` — the `/api/PlexMedia` endpoint
+- `src/Application/PlexMedia/WarmupMediaQueryCacheCommand.cs` — the warmup command
+- `src/BackgroundJobs/LibrarySync/Commands/RefreshLibraryMedia/*` — any refresh command that invalidates the cache
+- `src/BackgroundJobs/LibrarySync/Commands/SyncPlexMoviesCommand.cs` or `SyncPlexTvShowsCommand.cs` — bulk media sync
+- `src/PlexApi/PlexMedia/GetAllMediaByTypeFromPlexAPI/GetAllMediaByTypeFromPlexAPICommandHandler.cs` — Plex API fetching
+- `src/FluentResultExtensions/DTO/ResultDTOMapper.cs` — status code mapping (503)
+- `src/AppHost/ClientApp/src/store/mediaOverviewStore.ts` — frontend overview store
+- `src/AppHost/ClientApp/src/components/MediaOverview/MediaOverview.vue` — overview component
+- `src/AppHost/ClientApp/src/lang/*.json` — i18n keys for cache state messages
+- `src/AppHost/Boot.cs` — startup sequence that triggers warmup
+
+---
+
+## Architecture overview
+
+The media overview cache sits between the `GET /api/PlexMedia` endpoint and the database. Its job is to avoid running the full media query for every sort-direction change, page navigation, or filter toggle.
+
+```
+┌──────────────────────────────────────────────┐
+│  Browser: MediaOverview.vue                   │
+│  → mediaOverviewStore.refreshMediaData()      │
+│  → GET /api/PlexMedia?page=1&size=100&...     │
+└──────────────────┬───────────────────────────┘
+                   │
+┌──────────────────▼───────────────────────────┐
+│  Backend: GetAllMediaByTypeEndpoint           │
+│  → IMediaQueryCache.GetMediaAsync(filter)     │
+└──────────────────┬───────────────────────────┘
+                   │
+         ┌─────────▼──────────┐
+         │ MediaQueryCache    │
+         │ (SingleInstance)   │
+         │                    │
+         │  _metadataSnapshots│ ← keyed by MediaQueryMetadataKey
+         │  _sortedListSnaps  │ ← keyed by MediaQuerySortedListKey
+         │  _builds (in-flight│ ← ConcurrentDictionary<Lazy<>>
+         │  _dirtyKeys        │ ← stale-marker for background refresh
+         └─────────┬──────────┘
+                   │ (cache miss → background build)
+         ┌─────────▼──────────┐
+         │ ICommandExecutor   │
+         │ GetMediaByTypeCmd  │
+         └─────────┬──────────┘
+                   │
+         ┌─────────▼──────────┐
+         │ EF Core + SQLite    │
+         │ (real query)       │
+         └────────────────────┘
+```
+
+## Cache key structure
+
+Two-level keying:
+
+### `MediaQueryMetadataKey`
+Identifies what data scope:
+- `MediaType` — Movie or TvShow
+- `LibraryIds` — normalized sorted list of resolved library IDs (0 → all libraries)
+- `FilterOfflineMedia` — exclude libraries on offline servers
+- `FilterOwnedMedia` — exclude owned-media libraries
+
+### `MediaQuerySortedListKey`
+Adds sort ordering:
+- `MetadataKey` — the parent metadata key
+- `NormalizedAscendingSortField` — canonical ascending sort field name
+
+Sort normalization rules (see `MediaSortNormalizer`):
+| Library count | `sortIndex` field | `SearchTitle` field |
+|---------------|-------------------|---------------------|
+| 1             | `"sortIndex"`     | `"searchTitle"`     |
+| > 1           | `"SearchTitle"`   | `"SearchTitle"`     |
+
+The ascending snapshot in `_sortedListSnapshots` is reversed in-memory when the request asks for descending.
+
+## Cache hit flow (normal, warm)
+
+1. `GetMediaAsync` resolves library IDs from the filter, normalizes the sort field.
+2. Builds `metadataKey` + `sortedListKey`.
+3. Looks up both in `_metadataSnapshots` and `_sortedListSnapshots`.
+4. **Hit:** if key is dirty, queues a background refresh. Returns the existing snapshot as `Result.Ok`.
+5. **Miss:** queues a background build. Returns `Result.Fail("...")` with `503 Service Unavailable`.
+
+## Cache miss flow (cold or post-invalidation)
+
+1. `GetMediaAsync` returns 503 immediately — **no synchronous blocking**.
+2. `QueueSnapshotRefresh` creates a `Lazy<Task<...>>` for the key and launches a fire-and-forget `ObserveBuildAsync`.
+3. `ObserveBuildAsync` calls `BuildAndStoreSnapshotAsync`, then on success stores the metadata + sorted list snapshots and removes the dirty marker.
+4. On the next request that hits this key, the cache returns it in < 1ms.
+
+## Invalidation flow
+
+Previously: `InvalidateLibraries` removed metadata snapshots, sorted-list snapshots, AND cancelled in-flight builds (ConcurrentDictionary version-bumping). This was **destructive** — a single library refresh nuked the all-libraries snapshot for "All movies".
+
+Now: `InvalidateLibraries` **marks keys as dirty** (unless `SuppressInvalidation` is active):
+1. Finds all metadata + sorted-list keys that contain the affected library IDs.
+2. Sets `_dirtyKeys[key] = true`.
+3. Queues background refresh for affected sorted-list keys.
+4. Old snapshots stay in place — requests serve stale data while rebuilds run.
+
+On successful rebuild, `BuildAndStoreSnapshotAsync` atomically swaps the new snapshot and removes the dirty flag.
+
+## Warmup flow (BuildCache)
+
+Called at startup (`Boot.cs`) and after sync quiesce (`WarmupMediaQueryCacheCommand`):
+
+1. Resolves **all** Movie and TvShow library IDs.
+2. Builds 16 snapshots: 8 sort fields × 2 media types.
+   - Sort fields: `SortIndex`, `SearchTitle`, `Year`, `AddedAt`, `UpdatedAt`, `Duration`, `MediaSize`, `quality`
+3. Each snapshot runs `GetMediaByTypeCommand` via `ICommandExecutor` with `plexLibraryId=0`, no page/size limits.
+4. Results are stored in `_metadataSnapshots` and `_sortedListSnapshots`.
+5. `Has201CreatedRequestSuccess` on the command result is stripped so the status code doesn't leak.
+
+## Bypass conditions
+
+The cache is **bypassed** (query sent directly to DB) when:
+- `filter.Parameters.Query` is non-empty (search text)
+- `filter.Parameters.Filter` is non-empty (FlexQuery filter DSL)
+
+These are full DB queries; the cache only stores unfiltered overviews.
+
+## Frontend error handling
+
+`mediaOverviewStore.ts`:
+- `state.serverError` — set to `true` when `addMediaPage` receives null data (503, 504, network error).
+- `state.cacheRetrySeconds` — countdown timer displayed in the component.
+- On null data, starts a 5-second countdown that auto-triggers `refreshMediaData()`.
+- `refreshMediaData()` clears the timer and resets `serverError` before each request.
+
+`MediaOverview.vue`:
+- Checks `mediaOverviewStore.serverError` **before** `allMediaMode`.
+- Shows translated `failed-to-load-media` message with retry countdown.
+
+## i18n keys
+
+| Key | Purpose |
+|-----|---------|
+| `components.media-overview.failed-to-load-media` | Shown when backend returns 503/504/error |
+| `components.media-overview.no-media-items-found` | Shown when cache hit but truly 0 items |
+
+## Service registration
+
+`MediaQueryCache` is registered as `SingleInstance` in `DataModule`:
+```csharp
+// src/Data/_Shared/Config/Autofac/DataModule.cs
+builder.RegisterType<MediaQueryCache>().As<IMediaQueryCache>().SingleInstance();
+```
+
+## 503 status code mapping
+
+`ResultDTOMapper.ToStatusCode` maps `Has503ServiceUnavailableError → 503`. The cache returns:
+```csharp
+Result.Fail(CacheWarmingUpMessage).Add503ServiceUnavailableError();
+```
+
+This hits `Send.FluentResult(result, ct)` → `SendFluentResultDTOAsync` → `StatusCode = 503`.
+
+## Library sync → cache interaction
+
+```
+RefreshLibraryMediaCommand
+  → GetLibraryMediaFromPlexApiCommand     (fetch from Plex API)
+  → InsertMediaMetaDataCommand            (insert genres/countries/actors)
+  → SyncPlexLibraryMediaMetaDataCommand   (sync metadata relations)
+  → RefreshPlexMovieLibraryCommand        (movie-specific)
+  │   → SyncPlexMoviesCommand             (delete + reinsert)
+  │   → mediaQueryCache.InvalidateLibrary(plexLibraryId)
+  │
+  → RefreshPlexTvShowLibraryCommand       (TV-specific)
+  │   → SyncPlexTvShowsCommand            (delete + reinsert)
+  │   → mediaQueryCache.InvalidateLibrary(plexLibraryId)
+```
+
+**Critical:** `GetAllMediaByTypeFromPlexAPICommandHandler` must return an **error** (not empty success) on Plex API timeout. A timeout returning 0 media causes the library sync to delete all existing DB media and treat the refresh as "successful empty library."
+
+## Common pitfalls
+
+### 1. Key mismatch between warmup and request
+`BuildCache` must pass the **actual** resolved library count to `MediaSortNormalizer.Normalize`, not 0. With `libraryCount=0`, single-library warmups normalize `SortIndex → SearchTitle` but single-library requests normalize `sortIndex → "sortIndex"`. The keys never match, and the warmup is useless.
+
+### 2. Competing Normalize extension method
+`FlexQuery.NET.dll` also defines a `Normalize` extension on `string`. Always use `MediaSortNormalizer.Normalize(filter.Parameters.Sort, count)` fully qualified. Without qualification, the compiler resolves to the wrong overload.
+
+### 3. Singleton state leaks
+`MediaQueryCache` is a singleton. All dictionaries (`_metadataSnapshots`, `_sortedListSnapshots`, `_builds`, `_dirtyKeys`) persist across requests. Integration tests must clear or reset these between test runs.
+
+### 4. Sync delete-then-reinsert is a point of no return
+`SyncPlexMoviesCommand.RemoveMedia` uses `CancellationToken.None` and deletes all movies before reinserting. If the reinsert fails, the data is gone. Always verify Plex API success before reaching this point.
+
+### 5. Plex response missing TotalSize
+`GetAllMediaByTypeFromPlexAPICommandHandler.GetLibraryMediaTotalCount` defaults `TotalSize` to 0 when missing. A missing `TotalSize` with valid metadata is indistinguishable from an empty library.
+
+### 6. SuppressInvalidation is reset in finally block
+Phase 2 of the startup warmup wraps the suppression flag in try/finally: the flag is always reset regardless of cancellation or exception. Do not remove the finally block — if `SuppressInvalidation` stays `true`, all library sync invalidation becomes permanently disabled for the lifetime of the container.
+
+### 7. SyncQuietPeriod is protected virtual with setter
+Tests override it via reflection. If the property signature changes (e.g. back to expression-bodied), tests break with "Property set method not found." Keep the `{ get; set; }` form.
+
+## Related ADRs / issues
+
+- GitHub issue (SignalR cache-warmup events): tracks replacing the frontend polling retry with real-time SignalR notifications when cache warmup starts/completes.
+
+---
+
+## Startup phased warmup (anti-doom-loop)
+
+`WarmupMediaQueryCacheCommand` is called from `Boot.cs` at startup. It runs in three phases to avoid cache-doom loops during the initial library sync storm:
+
+```
+Phase 1: BuildCache() immediately from existing DB data
+  → Users see media instantly on container restart
+  → If DB is empty (fresh install), builds empty cache quickly
+
+Phase 2: SuppressInvalidation = true
+  → Library sync storm runs freely
+  → InvalidateLibrary / InvalidateLibraries are no-ops
+  → Cache serves stale (phase-1) data — no 503, no doom loops
+  → Wait for all LibrarySyncJobQueues to settle + 5 min quiet period
+
+Phase 3: SuppressInvalidation = false, then BuildCache()
+  → One clean rebuild after sync storm ends
+  → Future invalidations work normally (dirty-mark + background refresh)
+```
+
+**`SuppressInvalidation`** is a boolean property on `IMediaQueryCache` / `MediaQueryCache`:
+- Default `false`
+- When `true`, `InvalidateLibraries` logs a debug message and returns without marking keys dirty
+- Only set during Phase 2 of the startup warmup
+- Normal operation (user-triggered ownership/access changes) always has it `false`
+
+### SyncQuietPeriod
+
+The quiet period defaults to 5 minutes and is overridable for tests via `protected virtual TimeSpan SyncQuietPeriod { get; set; }`.
+
+After the quiet period elapses, the handler re-checks for newly queued sync jobs. If any are found, it waits again. This handles sync chains where completing one library refresh queues the next.
+
+## i18n keys
+
+| Key | Purpose |
+|-----|---------|
+| `components.media-overview.failed-to-load-media` | Shown when backend returns 503/504/error |
+| `components.media-overview.retrying-in-seconds` | Shown with countdown during auto-retry (e.g. "Retrying in 5s...") |
+| `components.media-overview.no-media-items-available` | Shown when cache hit but truly 0 items in all-media mode |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-@AGENTS.md

--- a/paseo.json
+++ b/paseo.json
@@ -1,5 +1,0 @@
-{
-  "worktree": {
-    "setup": "bun install --cwd ./src/AppHost/ClientApp && dotnet restore"
-  }
-}

--- a/src/AppHost/ClientApp/src/components/MediaOverview/MediaOverview.vue
+++ b/src/AppHost/ClientApp/src/components/MediaOverview/MediaOverview.vue
@@ -132,6 +132,7 @@ function resetProgress() {
 
 function refreshLibrary() {
 	resetProgress();
+	mediaOverviewStore.loading = true;
 	useSubscription(
 		libraryStore.reSyncLibrary(mediaOverviewStore.libraryId).subscribe(),
 	);
@@ -194,6 +195,16 @@ function onOptionsClosed(hasChanged: boolean) {
 		useSubscription(mediaOverviewStore.refreshMediaData().subscribe());
 	}
 }
+
+// Refresh media data when a library sync completes.
+watch(
+	() => libraryStore.getIsLibrarySyncing(props.libraryId),
+	(isSyncing, wasSyncing) => {
+		if (wasSyncing && !isSyncing) {
+			useSubscription(mediaOverviewStore.refreshMediaData().subscribe());
+		}
+	},
+);
 
 onMounted(() => {
 	resetProgress();

--- a/src/AppHost/ClientApp/src/components/MediaOverview/MediaOverview.vue
+++ b/src/AppHost/ClientApp/src/components/MediaOverview/MediaOverview.vue
@@ -44,7 +44,13 @@
 						<QCol cols="auto">
 							<QAlert
 								type="warning">
-								<template v-if="mediaOverviewStore.allMediaMode">
+								<template v-if="mediaOverviewStore.serverError">
+									{{ t('components.media-overview.failed-to-load-media') }}
+									<template v-if="mediaOverviewStore.cacheRetrySeconds > 0">
+										{{ t('components.media-overview.retrying-in-seconds', { seconds: mediaOverviewStore.cacheRetrySeconds }) }}
+									</template>
+								</template>
+								<template v-else-if="mediaOverviewStore.allMediaMode">
 									{{ t('components.media-overview.no-media-items-available') }}
 								</template>
 								<template v-else-if="mediaOverviewStore.hasNoSearchResults">

--- a/src/AppHost/ClientApp/src/lang/de-DE.json
+++ b/src/AppHost/ClientApp/src/lang/de-DE.json
@@ -105,6 +105,8 @@
             "library-not-yet-synced": "Die Mediendaten der Bibliothek wurden noch nicht synchronisiert. Bitte warten Sie oder aktualisieren Sie jetzt.",
             "no-search-results": "Es wurden keine Medien gefunden, die \"{query}\" enthalten.",
             "no-media-items-available": "Keine Medienelemente gefunden!",
+            "failed-to-load-media": "Fehler beim Laden der Medien. Der Server ist möglicherweise ausgelastet. Bitte versuchen Sie es erneut oder warten Sie, bis der Cache aufgewärmt ist.",
+            "retrying-in-seconds": "Erneuter Versuch in {seconds}s...",
             "no-filter-results": "Keine Medienergebnisse entsprechen den aktuellen Filtereinstellungen. Bitte passen Sie Ihre Filter an oder setzen Sie sie zurück, um die verfügbaren Ergebnisse anzuzeigen"
         },
         "navigation-drawer": {

--- a/src/AppHost/ClientApp/src/lang/en-US.json
+++ b/src/AppHost/ClientApp/src/lang/en-US.json
@@ -105,6 +105,8 @@
             "library-not-yet-synced": "The library media data has not yet been synced. Please wait or refresh now.",
             "no-search-results": "No media found that contains \"{query}\"",
             "no-media-items-available": "No media items found!",
+            "failed-to-load-media": "Failed to load media. The server may be busy. Please try again or wait for the cache to warm up.",
+            "retrying-in-seconds": "Retrying in {seconds}s...",
             "no-filter-results": "No media results match the current filter settings. Please adjust or reset your filters to display available results"
         },
         "navigation-drawer": {

--- a/src/AppHost/ClientApp/src/lang/fr-FR.json
+++ b/src/AppHost/ClientApp/src/lang/fr-FR.json
@@ -105,6 +105,8 @@
             "library-not-yet-synced": "Les données multimédias de la bibliothèque n'ont pas encore été synchronisées. Veuillez patienter ou actualiser maintenant.",
             "no-search-results": "Aucun média contenant \"{query}\" n'a été trouvé",
             "no-media-items-available": "Aucun élément multimédia trouvé!",
+            "failed-to-load-media": "Échec du chargement des médias. Le serveur est peut-être occupé. Veuillez réessayer ou attendre que le cache se réchauffe.",
+            "retrying-in-seconds": "Nouvelle tentative dans {seconds}s...",
             "no-filter-results": "Aucun résultat multimédia ne correspond aux paramètres de filtre actuels. Veuillez ajuster ou réinitialiser vos filtres pour afficher les résultats disponibles."
         },
         "navigation-drawer": {

--- a/src/AppHost/ClientApp/src/lang/pl-PL.json
+++ b/src/AppHost/ClientApp/src/lang/pl-PL.json
@@ -105,6 +105,8 @@
             "library-not-yet-synced": "Dane multimediów bibliotecznych nie zostały jeszcze zsynchronizowane. Proszę czekać lub odświeżyć teraz.",
             "no-search-results": "Nie znaleziono nośników zawierających „{query}”",
             "no-media-items-available": "Nie znaleziono żadnych elementów multimedialnych!",
+            "failed-to-load-media": "Nie udało się załadować multimediów. Serwer może być zajęty. Spróbuj ponownie lub poczekaj na rozgrzanie pamięci podręcznej.",
+            "retrying-in-seconds": "Ponowna próba za {seconds}s...",
             "no-filter-results": "Brak wyników wyszukiwania multimediów zgodnych z aktualnymi ustawieniami filtra. Dostosuj lub zresetuj filtry, aby wyświetlić dostępne wyniki."
         },
         "navigation-drawer": {

--- a/src/AppHost/ClientApp/src/store/mediaOverviewStore.ts
+++ b/src/AppHost/ClientApp/src/store/mediaOverviewStore.ts
@@ -143,6 +143,9 @@ export const useMediaOverviewStore = defineStore(StoreNames.MediaOverviewStore, 
 
 			actions.$reset();
 
+			// Prevent the empty-state flash while data loads.
+			state.loading = true;
+
 			// Update state
 			state.libraryId = libraryId;
 

--- a/src/AppHost/ClientApp/src/store/mediaOverviewStore.ts
+++ b/src/AppHost/ClientApp/src/store/mediaOverviewStore.ts
@@ -57,6 +57,8 @@ interface IMediaOverviewStoreState {
 	mediaPagesVersion: number;
 	currentScrollIndex: number;
 	scrollCommand: BehaviorSubject<number>;
+	serverError: boolean;
+	cacheRetrySeconds: number;
 }
 
 export const useMediaOverviewStore = defineStore(StoreNames.MediaOverviewStore, () => {
@@ -105,6 +107,8 @@ export const useMediaOverviewStore = defineStore(StoreNames.MediaOverviewStore, 
 		mediaPagesVersion: 0,
 		currentScrollIndex: 0,
 		scrollCommand: new BehaviorSubject<number>(0),
+		serverError: false,
+		cacheRetrySeconds: 0,
 	};
 
 	const state = reactive<IMediaOverviewStoreState>(cloneDeep(defaultState));
@@ -112,6 +116,7 @@ export const useMediaOverviewStore = defineStore(StoreNames.MediaOverviewStore, 
 	const libraryStore = useLibraryStore();
 	const mediaPages = new Map<number, readonly PlexMediaSlimDTO[]>();
 	const pendingPages = new Set<number>();
+	let cacheRetryTimer: ReturnType<typeof setInterval> | null = null;
 
 	const searchQuery = useRouteQuery('q', '', { mode: 'replace' });
 	const countryIdQuery = useRouteQuery('countryId', 0, { mode: 'replace' });
@@ -194,6 +199,9 @@ export const useMediaOverviewStore = defineStore(StoreNames.MediaOverviewStore, 
 			}
 
 			state.loading = true;
+			state.serverError = false;
+	state.cacheRetrySeconds = 0;
+	clearCacheRetryTimer();
 
 			mediaPages.clear();
 			pendingPages.clear();
@@ -256,6 +264,8 @@ export const useMediaOverviewStore = defineStore(StoreNames.MediaOverviewStore, 
 		// Adds the requested media page to the cache
 		addMediaPage(data: PlexMediaStatisticsDTO | null) {
 			if (!data) {
+				state.serverError = true;
+				startCacheRetry();
 				Log.error('Received null data for media page');
 				return;
 			}
@@ -479,6 +489,28 @@ export const useMediaOverviewStore = defineStore(StoreNames.MediaOverviewStore, 
 			Object.assign(state, cloneDeep(defaultState));
 		},
 	};
+
+	// ── Cache retry helpers ────────────────────────────────
+
+	function startCacheRetry(): void {
+		if (cacheRetryTimer !== null) return;
+		state.cacheRetrySeconds = 5;
+		cacheRetryTimer = setInterval(() => {
+			state.cacheRetrySeconds--;
+			if (state.cacheRetrySeconds <= 0) {
+				clearCacheRetryTimer();
+				actions.refreshMediaData().subscribe();
+			}
+		}, 1000);
+	}
+
+	function clearCacheRetryTimer(): void {
+		if (cacheRetryTimer !== null) {
+			clearInterval(cacheRetryTimer);
+			cacheRetryTimer = null;
+		}
+		state.cacheRetrySeconds = 0;
+	}
 
 	const getters = {
 		hasSelectedMedia: computed((): boolean => {

--- a/src/AppHost/ClientApp/src/store/mediaOverviewStore.ts
+++ b/src/AppHost/ClientApp/src/store/mediaOverviewStore.ts
@@ -193,7 +193,6 @@ export const useMediaOverviewStore = defineStore(StoreNames.MediaOverviewStore, 
 			);
 		},
 		refreshMediaData(): Observable<PlexMediaStatisticsDTO | null> {
-			state.serverError = false;
 			state.cacheRetrySeconds = 0;
 			clearCacheRetryTimer();
 
@@ -263,6 +262,8 @@ export const useMediaOverviewStore = defineStore(StoreNames.MediaOverviewStore, 
 				Log.error('Received null data for media page');
 				return;
 			}
+
+			state.serverError = false;
 
 			if (state.queryHash !== data.queryHash) {
 				Log.warn(`mediaPages was cleared, with ${state.queryHash} vs ${data.queryHash}`);
@@ -488,7 +489,7 @@ export const useMediaOverviewStore = defineStore(StoreNames.MediaOverviewStore, 
 	// ── Cache retry helpers ────────────────────────────────
 
 	function startCacheRetry(): void {
-		if (cacheRetryTimer !== null || state.loading) return;
+		if (cacheRetryTimer !== null) return;
 		state.cacheRetrySeconds = 5;
 		cacheRetryTimer = setInterval(() => {
 			state.cacheRetrySeconds--;

--- a/src/AppHost/ClientApp/src/store/mediaOverviewStore.ts
+++ b/src/AppHost/ClientApp/src/store/mediaOverviewStore.ts
@@ -489,7 +489,7 @@ export const useMediaOverviewStore = defineStore(StoreNames.MediaOverviewStore, 
 
 	function startCacheRetry(): void {
 		if (cacheRetryTimer !== null || state.loading) return;
-			state.cacheRetrySeconds = 5;
+		state.cacheRetrySeconds = 5;
 		cacheRetryTimer = setInterval(() => {
 			state.cacheRetrySeconds--;
 			if (state.cacheRetrySeconds <= 0) {
@@ -504,7 +504,7 @@ export const useMediaOverviewStore = defineStore(StoreNames.MediaOverviewStore, 
 			clearInterval(cacheRetryTimer);
 			cacheRetryTimer = null;
 		}
-			state.cacheRetrySeconds = 0;
+		state.cacheRetrySeconds = 0;
 	}
 
 	const getters = {

--- a/src/AppHost/ClientApp/src/store/mediaOverviewStore.ts
+++ b/src/AppHost/ClientApp/src/store/mediaOverviewStore.ts
@@ -194,8 +194,8 @@ export const useMediaOverviewStore = defineStore(StoreNames.MediaOverviewStore, 
 		},
 		refreshMediaData(): Observable<PlexMediaStatisticsDTO | null> {
 			state.serverError = false;
-		state.cacheRetrySeconds = 0;
-		clearCacheRetryTimer();
+			state.cacheRetrySeconds = 0;
+			clearCacheRetryTimer();
 
 			mediaPages.clear();
 			pendingPages.clear();
@@ -489,7 +489,7 @@ export const useMediaOverviewStore = defineStore(StoreNames.MediaOverviewStore, 
 
 	function startCacheRetry(): void {
 		if (cacheRetryTimer !== null || state.loading) return;
-		state.cacheRetrySeconds = 5;
+			state.cacheRetrySeconds = 5;
 		cacheRetryTimer = setInterval(() => {
 			state.cacheRetrySeconds--;
 			if (state.cacheRetrySeconds <= 0) {
@@ -504,7 +504,7 @@ export const useMediaOverviewStore = defineStore(StoreNames.MediaOverviewStore, 
 			clearInterval(cacheRetryTimer);
 			cacheRetryTimer = null;
 		}
-		state.cacheRetrySeconds = 0;
+			state.cacheRetrySeconds = 0;
 	}
 
 	const getters = {

--- a/src/AppHost/ClientApp/src/store/mediaOverviewStore.ts
+++ b/src/AppHost/ClientApp/src/store/mediaOverviewStore.ts
@@ -143,9 +143,6 @@ export const useMediaOverviewStore = defineStore(StoreNames.MediaOverviewStore, 
 
 			actions.$reset();
 
-			// Prevent the empty-state flash while data loads.
-			state.loading = true;
-
 			// Update state
 			state.libraryId = libraryId;
 
@@ -196,15 +193,9 @@ export const useMediaOverviewStore = defineStore(StoreNames.MediaOverviewStore, 
 			);
 		},
 		refreshMediaData(): Observable<PlexMediaStatisticsDTO | null> {
-			if (state.loading) {
-				Log.debug('Request already in progress, skipping');
-				return of(null);
-			}
-
-			state.loading = true;
 			state.serverError = false;
-	state.cacheRetrySeconds = 0;
-	clearCacheRetryTimer();
+		state.cacheRetrySeconds = 0;
+		clearCacheRetryTimer();
 
 			mediaPages.clear();
 			pendingPages.clear();
@@ -490,13 +481,14 @@ export const useMediaOverviewStore = defineStore(StoreNames.MediaOverviewStore, 
 			mediaPages.clear();
 			pendingPages.clear();
 			Object.assign(state, cloneDeep(defaultState));
+			state.loading = true;
 		},
 	};
 
 	// ── Cache retry helpers ────────────────────────────────
 
 	function startCacheRetry(): void {
-		if (cacheRetryTimer !== null) return;
+		if (cacheRetryTimer !== null || state.loading) return;
 		state.cacheRetrySeconds = 5;
 		cacheRetryTimer = setInterval(() => {
 			state.cacheRetrySeconds--;

--- a/src/AppHost/ClientApp/tests/nuxt/stores/media-overview-store/cache-retry.test.ts
+++ b/src/AppHost/ClientApp/tests/nuxt/stores/media-overview-store/cache-retry.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { baseSetup, baseVars, getAxiosMock, subscribeSpyTo } from '@services-test-base';
+import {
+	generatePlexMediaSlims,
+	generatePlexMediaStatisticsDTO,
+	generateResultDTO,
+} from '@mock';
+import { useMediaOverviewStore } from '@store';
+import { PlexMediaType } from '@dto';
+
+interface MockResponse {
+	isSuccess: boolean;
+	statusCode: number;
+	errors: Array<{ message: string; reasons: never[]; metadata: Record<string, never> }>;
+	successes: never[];
+	value: null;
+}
+
+describe('MediaOverviewStore - Cache Retry', () => {
+	let { mock } = baseVars();
+
+	beforeAll(() => {
+		baseSetup();
+	});
+
+	beforeEach(() => {
+		mock = getAxiosMock();
+		setActivePinia(createPinia());
+		vi.useFakeTimers({ shouldAdvanceTime: false, toFake: ['setInterval', 'clearInterval', 'Date'] });
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	function setupFilterMocks() {
+		mock.onGet(new RegExp('/api/PlexLibrary/0/metadata-filter')).reply(200, generateResultDTO({
+			countries: [],
+			genres: [],
+			qualities: [],
+			roles: [],
+		}));
+		mock.onGet(new RegExp('/api/PlexLibrary/0/metadata\\?')).reply(200, generateResultDTO({
+			episodeCount: 0, mediaCount: 0, mediaSize: 0, movieCount: 0, seasonCount: 0, tvShowCount: 0,
+			mediaList: [], roles: [], countries: [], genres: [], qualities: [],
+			roleCount: 0, countryCount: 0, genreCount: 0, qualityCount: 0,
+		}));
+	}
+
+	function mediaFailureResponse(): [number, MockResponse] {
+		return [200, {
+			isSuccess: false, statusCode: 503,
+			errors: [{ message: 'Cache warming up', reasons: [], metadata: {} }],
+			successes: [], value: null,
+		}];
+	}
+
+	function mediaSuccessResponse(): [number, ReturnType<typeof generateResultDTO>] {
+		const movies = generatePlexMediaStatisticsDTO(generatePlexMediaSlims({
+			config: { movieCount: 5 },
+			partialData: { plexServerId: 1, plexLibraryId: 0, type: PlexMediaType.Movie },
+		}));
+		return [200, generateResultDTO(movies)];
+	}
+
+	/** Advance through one full retry cycle: 5 interval ticks → refresh fires */
+	async function advanceRetryCycle() {
+		await vi.advanceTimersByTimeAsync(5000);
+	}
+
+	test('should auto-retry with countdown when cache is warming up', async () => {
+		let callCount = 0;
+		mock.onGet(new RegExp('/api/PlexMedia')).reply(() => {
+			callCount++;
+			if (callCount <= 2) return mediaFailureResponse();
+			return mediaSuccessResponse();
+		});
+		setupFilterMocks();
+
+		const store = useMediaOverviewStore();
+		subscribeSpyTo(store.refreshMediaData());
+
+		await vi.advanceTimersByTimeAsync(1000);
+		expect(callCount).toBe(1);
+		expect(store.serverError).toBe(true);
+		expect(store.cacheRetrySeconds).toBe(4);
+
+		await vi.advanceTimersByTimeAsync(4000);
+		expect(callCount).toBe(2);
+		expect(store.serverError).toBe(true);
+
+		await advanceRetryCycle();
+		expect(callCount).toBe(3);
+		expect(store.serverError).toBe(false);
+		expect(store.itemsLength).toBe(5);
+	});
+
+	test('should retry N times until cache is ready', async () => {
+		let callCount = 0;
+		mock.onGet(new RegExp('/api/PlexMedia')).reply(() => {
+			callCount++;
+			if (callCount <= 3) return mediaFailureResponse();
+			return mediaSuccessResponse();
+		});
+		setupFilterMocks();
+
+		const store = useMediaOverviewStore();
+		subscribeSpyTo(store.refreshMediaData());
+		await vi.advanceTimersByTimeAsync(1000);
+		expect(callCount).toBe(1);
+		expect(store.serverError).toBe(true);
+
+		await vi.advanceTimersByTimeAsync(4000);
+		expect(callCount).toBe(2);
+		expect(store.serverError).toBe(true);
+
+		await advanceRetryCycle();
+		expect(callCount).toBe(3);
+		expect(store.serverError).toBe(true);
+
+		await advanceRetryCycle();
+		expect(callCount).toBe(4);
+		expect(store.serverError).toBe(false);
+		expect(store.itemsLength).toBe(5);
+	});
+
+	test('refreshMediaData called manually while retrying should clear the retry', async () => {
+		mock.onGet(new RegExp('/api/PlexMedia')).reply(() => mediaFailureResponse());
+		setupFilterMocks();
+
+		const store = useMediaOverviewStore();
+		subscribeSpyTo(store.refreshMediaData());
+		await vi.advanceTimersByTimeAsync(1000);
+		expect(store.serverError).toBe(true);
+		expect(store.cacheRetrySeconds).toBe(4);
+
+		store.refreshMediaData().subscribe();
+		expect(store.cacheRetrySeconds).toBe(0);
+	});
+});

--- a/src/AppHost/ClientApp/tests/nuxt/stores/media-overview-store/loading-state.test.ts
+++ b/src/AppHost/ClientApp/tests/nuxt/stores/media-overview-store/loading-state.test.ts
@@ -68,7 +68,7 @@ describe('MediaOverviewStore - Loading State', () => {
 		expect(result.receivedComplete()).toBe(true);
 	});
 
-	test('requestMedia should return of(null) immediately when loading is already true', async () => {
+	test('refreshMediaData should execute again even when loading is already true', async () => {
 		// Arrange
 		const store = useMediaOverviewStore();
 		const movies = generatePlexMediaStatisticsDTO(generatePlexMediaSlims({
@@ -80,12 +80,12 @@ describe('MediaOverviewStore - Loading State', () => {
 		// Start first request but don't await it
 		const first = subscribeSpyTo(store.refreshMediaData());
 
-		// Act — second call while loading is true
+		// Act — second call while loading is true (no longer skipped)
 		const second = subscribeSpyTo(store.refreshMediaData());
 		await second.onComplete();
 
-		// Assert — second call completes immediately with null (skipped)
-		expect(second.getLastValue()).toBeNull();
+		// Assert — second call returns data, not null (loading guard removed)
+		expect(second.getLastValue()).not.toBeNull();
 		expect(second.receivedComplete()).toBe(true);
 
 		// Clean up first

--- a/src/Application/PlexDownloads/Execute/DashDownloadClient/DashPlexDownloadClient.cs
+++ b/src/Application/PlexDownloads/Execute/DashDownloadClient/DashPlexDownloadClient.cs
@@ -258,6 +258,7 @@ public class DashPlexDownloadClient : IPlexDownloadClient
             var status =
                 completed.Result.Has404NotFoundError() ? DownloadStatus.SourceUnavailable
                 : completed.Result.IsServerUnreachable() ? DownloadStatus.ServerUnreachable
+                : completed.Result.HasStorageError() ? DownloadStatus.StorageError
                 : DownloadStatus.DownloadClientError;
             var statusResult = await SetDownloadStatusAsync(status, completed.Result);
             if (statusResult.IsFailed)

--- a/src/Application/PlexDownloads/Execute/DirectDownloadClient/DirectPlexDownloadClient.cs
+++ b/src/Application/PlexDownloads/Execute/DirectDownloadClient/DirectPlexDownloadClient.cs
@@ -62,6 +62,7 @@ public class DirectPlexDownloadClient : IPlexDownloadClient
         _configuration.EnableAutoResumeDownload = false;
         _configuration.DownloadFileExtension = FilePathExtensions.TempDownloadFileSuffix;
         _configuration.CheckDiskSizeBeforeDownload = false;
+        _configuration.MaximumMemoryBufferBytes = 50 * 1024 * 1024; // 50MB memory buffer cap
 
         _downloader = downloadServiceFactory(_configuration);
     }

--- a/src/Application/PlexDownloads/Execute/DirectDownloadClient/DirectPlexDownloadClient.cs
+++ b/src/Application/PlexDownloads/Execute/DirectDownloadClient/DirectPlexDownloadClient.cs
@@ -282,6 +282,7 @@ public class DirectPlexDownloadClient : IPlexDownloadClient
                             var failedStatus =
                                 downloadErrorResult.Has404NotFoundError() ? Domain.DownloadStatus.SourceUnavailable
                                 : downloadErrorResult.IsServerUnreachable() ? Domain.DownloadStatus.ServerUnreachable
+                                : downloadErrorResult.HasStorageError() ? Domain.DownloadStatus.StorageError
                                 : Domain.DownloadStatus.Error;
 
                             var statusResult = await SetDownloadStatusAsync(failedStatus, downloadErrorResult);

--- a/src/Application/PlexDownloads/Execute/DownloadJob.cs
+++ b/src/Application/PlexDownloads/Execute/DownloadJob.cs
@@ -139,6 +139,7 @@ public class DownloadJob : IJob
                 var failedStatus =
                     startResult.Has404NotFoundError() ? DownloadStatus.SourceUnavailable
                     : startResult.IsServerUnreachable() ? DownloadStatus.ServerUnreachable
+                    : startResult.HasStorageError() ? DownloadStatus.StorageError
                     : DownloadStatus.DownloadClientError;
 
                 await _downloadTaskUpdateDispatcher.OnStatusChangedAsync(

--- a/src/Application/PlexMedia/WarmupMediaQueryCacheCommand.cs
+++ b/src/Application/PlexMedia/WarmupMediaQueryCacheCommand.cs
@@ -13,7 +13,7 @@ public class WarmupMediaQueryCacheCommandValidator : AbstractValidator<WarmupMed
 public class WarmupMediaQueryCacheCommandHandler : ICommandHandler<WarmupMediaQueryCacheCommand, Result>
 {
     private static readonly TimeSpan _librarySyncPollInterval = TimeSpan.FromSeconds(2);
-    private static readonly TimeSpan _librarySyncQuietPeriod = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan _librarySyncQuietPeriod = TimeSpan.FromMinutes(5);
 
     private readonly ILogger _log;
     private readonly IMediaQueryCache _mediaQueryCache;
@@ -30,19 +30,50 @@ public class WarmupMediaQueryCacheCommandHandler : ICommandHandler<WarmupMediaQu
         _dbContextFactory = dbContextFactory;
     }
 
+    /// <summary>
+    /// Quiet period after syncs settle. Overridable for tests to avoid real delays.
+    /// </summary>
+    protected virtual TimeSpan SyncQuietPeriod { get; set; } = _librarySyncQuietPeriod;
+
     public async Task<Result> ExecuteAsync(WarmupMediaQueryCacheCommand command, CancellationToken cancellationToken) =>
         await Result.Try(async Task () =>
         {
-            while (true)
-            {
-                while (await HasActiveLibrarySyncJobsAsync(cancellationToken))
-                    await Task.Delay(_librarySyncPollInterval, cancellationToken);
+            // Phase 1: Warm cache immediately from existing DB data.
+            // This ensures returning users see media instantly on container restart.
+            _log.Here().Information("Phase 1: Building Media Query Cache from existing database state");
+            await _mediaQueryCache.BuildCache();
 
-                await Task.Delay(_librarySyncQuietPeriod, cancellationToken);
-                break;
+            // Suppress invalidation during the library sync storm so cache-doom loops
+            // are avoided. Ownership/access-triggered invalidations are deferred.
+            // Wrap in try/finally so cancellation always resets the flag.
+            _mediaQueryCache.SuppressInvalidation = true;
+            _log.Here().Debug("Media query cache invalidation suppressed until sync storm settles");
+
+            try
+            {
+                // Phase 2: Wait for all library sync jobs to quiesce.
+                while (true)
+                {
+                    while (await HasActiveLibrarySyncJobsAsync(cancellationToken))
+                        await Task.Delay(_librarySyncPollInterval, cancellationToken);
+
+                    // Re-check after quiet period — sync chains may have queued more jobs.
+                    await Task.Delay(SyncQuietPeriod, cancellationToken);
+
+                    if (!await HasActiveLibrarySyncJobsAsync(cancellationToken))
+                        break;
+
+                    _log.Here().Debug("New library sync jobs detected after quiet period, waiting again");
+                }
+            }
+            finally
+            {
+                // Always reset the suppression flag, even on cancellation.
+                _mediaQueryCache.SuppressInvalidation = false;
             }
 
-            _log.Here().Information("Building Media Query Cache from warmup");
+            // Phase 3: Final clean rebuild.
+            _log.Here().Information("Phase 3: Rebuilding Media Query Cache after library sync storm settled");
             await _mediaQueryCache.BuildCache();
         });
 

--- a/src/Data.Contracts/Cache/IMediaQueryCache.cs
+++ b/src/Data.Contracts/Cache/IMediaQueryCache.cs
@@ -9,4 +9,10 @@ public interface IMediaQueryCache
     void InvalidateLibrary(int plexLibraryId, string reason);
 
     void InvalidateLibraries(IReadOnlyCollection<int> plexLibraryIds, string reason);
+
+    /// <summary>
+    /// When true, InvalidateLibrary / InvalidateLibraries are no-ops.
+    /// Used during startup to suppress cache-doom loops while library sync storms are in progress.
+    /// </summary>
+    bool SuppressInvalidation { get; set; }
 }

--- a/src/Data/Cache/MediaQueryCache.cs
+++ b/src/Data/Cache/MediaQueryCache.cs
@@ -54,6 +54,10 @@ public sealed class MediaQueryCache : IMediaQueryCache
         MediaQueryFilter filter,
         CancellationToken cancellationToken)
     {
+        // Single-library queries are small — bypass the cache and hit the DB directly.
+        if (filter.PlexLibraryId > 0)
+            return await BypassCacheAsync(filter, cancellationToken, "specific library scope");
+
         if (!string.IsNullOrWhiteSpace(filter.Parameters.Query))
             return await BypassCacheAsync(filter, cancellationToken, "query parameter is set");
 

--- a/src/Data/Cache/MediaQueryCache.cs
+++ b/src/Data/Cache/MediaQueryCache.cs
@@ -9,6 +9,7 @@ namespace Reaparr.Data;
 /// </summary>
 public sealed class MediaQueryCache : IMediaQueryCache
 {
+    private const string CacheWarmingUpMessage = "Media query cache is warming up. The media overview will appear once the cache is built on the next request.";
     private static readonly string[] _warmupSortFields =
     [
         nameof(BasePlexMedia.SearchTitle),
@@ -30,6 +31,7 @@ public sealed class MediaQueryCache : IMediaQueryCache
     private readonly ConcurrentDictionary<MediaQuerySortedListKey, MediaQuerySortedListSnapshot> _sortedListSnapshots = new();
     private readonly ConcurrentDictionary<MediaQuerySortedListKey, Lazy<Task<Result<MediaQueryBuildResult>>>> _builds = new();
     private readonly ConcurrentDictionary<MediaQuerySortedListKey, long> _buildVersions = new();
+    private readonly ConcurrentDictionary<MediaQuerySortedListKey, bool> _dirtyKeys = new();
 
     private readonly ICommandExecutor _commandExecutor;
     private readonly IReaparrDbContextFactory _dbContextFactory;
@@ -43,6 +45,9 @@ public sealed class MediaQueryCache : IMediaQueryCache
         _dbContextFactory = dbContextFactory;
         _generalSettings = generalSettings;
     }
+
+    /// <inheritdoc />
+    public bool SuppressInvalidation { get; set; }
 
     /// <inheritdoc />
     public async Task<Result<PagedMediaQueryResult>> GetMediaAsync(
@@ -74,26 +79,41 @@ public sealed class MediaQueryCache : IMediaQueryCache
         if (_metadataSnapshots.TryGetValue(metadataKey, out var metadataSnapshot)
             && _sortedListSnapshots.TryGetValue(sortedListKey, out var sortedListSnapshot))
         {
+            if (_dirtyKeys.ContainsKey(sortedListKey))
+                QueueSnapshotRefresh(sortedListKey);
+
             _log.Here().Debug("Media query cache hit for {MediaType} sorted by {SortField}", filter.MediaType, sortedListKey.NormalizedAscendingSortField);
             return Result.Ok(CreatePage(filter, metadataSnapshot, sortedListSnapshot, sort.Descending));
         }
 
         _log.Here().Debug("Media query cache miss for {MediaType} sorted by {SortField}", filter.MediaType, sortedListKey.NormalizedAscendingSortField);
-        var buildResult = await GetOrBuildSnapshotAsync(filter, sortedListKey, sort, cancellationToken);
-        return buildResult.IsSuccess
-            ? Result.Ok(CreatePage(filter, buildResult.Value.Metadata, buildResult.Value.SortedList, sort.Descending))
-            : Result.Fail(buildResult.Errors);
+        QueueSnapshotRefresh(sortedListKey);
+        return Result.Fail(CacheWarmingUpMessage).Add503ServiceUnavailableError();
     }
 
     /// <inheritdoc />
     public async Task BuildCache()
     {
-        var warmupTasks = _warmupMediaTypes
+        // Resolve library IDs once for Movie and TvShow warmup keys
+        var movieLibraryIds = await ResolveLibraryIdsAsync(CreateWarmupFilter(PlexMediaType.Movie, _warmupSortFields[0]), CancellationToken.None);
+        var tvShowLibraryIds = await ResolveLibraryIdsAsync(CreateWarmupFilter(PlexMediaType.TvShow, _warmupSortFields[0]), CancellationToken.None);
+
+        var warmupFilters = _warmupMediaTypes
             .SelectMany(mediaType => _warmupSortFields
-                .Select(sortField => GetMediaAsync(CreateWarmupFilter(mediaType, sortField), CancellationToken.None)))
+                .Select(sortField =>
+                {
+                    var filter = CreateWarmupFilter(mediaType, sortField);
+                    var libraryIds = mediaType == PlexMediaType.Movie ? movieLibraryIds : tvShowLibraryIds;
+                    var normalizedSort = MediaSortNormalizer.Normalize(filter.Parameters.Sort, libraryIds.Count)!;
+                    var key = new MediaQuerySortedListKey(
+                        new MediaQueryMetadataKey(mediaType, libraryIds, filter.FilterOfflineMedia, filter.FilterOwnedMedia),
+                        normalizedSort.Field);
+                    return (Filter: filter, Key: key);
+                }))
             .ToList();
 
-        var results = await Task.WhenAll(warmupTasks);
+        var tasks = warmupFilters.Select(x => BuildAndStoreSnapshotAsync(x.Filter, x.Key, CancellationToken.None)).ToList();
+        var results = await Task.WhenAll(tasks);
         var failures = results.Where(x => x.IsFailed).SelectMany(x => x.Errors).ToList();
         if (failures.Count > 0)
         {
@@ -110,58 +130,52 @@ public sealed class MediaQueryCache : IMediaQueryCache
     /// <inheritdoc />
     public void InvalidateLibraries(IReadOnlyCollection<int> plexLibraryIds, string reason)
     {
+        if (SuppressInvalidation)
+        {
+            _log.Here().Debug("Skipping media query cache invalidation for libraries {PlexLibraryIds}: suppression active. Reason: {Reason}", plexLibraryIds, reason);
+            return;
+        }
         var affectedLibraryIds = plexLibraryIds.Where(x => x > 0).ToHashSet();
         if (affectedLibraryIds.Count == 0)
             return;
 
-        var removedMetadataCount = RemoveKeysContainingLibrary(_metadataSnapshots, affectedLibraryIds, k => k.ContainsAnyLibrary(affectedLibraryIds));
-        var removedSortedListCount = RemoveKeysContainingLibrary(_sortedListSnapshots, affectedLibraryIds, k => k.ContainsAnyLibrary(affectedLibraryIds));
-        var removedBuildCount = RemoveKeysContainingLibrary(_builds, affectedLibraryIds, k => k.ContainsAnyLibrary(affectedLibraryIds));
-
-        // Bump versions so in-flight builds that complete after this point discard their results.
-        var keysToBump = _buildVersions.Keys.Where(key => key.ContainsAnyLibrary(affectedLibraryIds)).ToList();
-        foreach (var key in keysToBump)
-            _buildVersions.AddOrUpdate(key, 1, (_, version) => version + 1);
+        var dirtyMetadataCount = MarkKeysContainingLibraryAsDirty(_metadataSnapshots, affectedLibraryIds, k => k.ContainsAnyLibrary(affectedLibraryIds));
+        var dirtySortedListCount = MarkKeysContainingLibraryAsDirty(_sortedListSnapshots, affectedLibraryIds, k => k.ContainsAnyLibrary(affectedLibraryIds));
+        var inFlightCount = CountKeysContainingLibrary(_builds, affectedLibraryIds, k => k.ContainsAnyLibrary(affectedLibraryIds));
 
         _log.Here().Information(
             "Invalidated media query cache for libraries {PlexLibraryIds}: {Reason}. " +
-            "Removed {MetadataCount} metadata, {SortedListCount} sorted-lists, {BuildCount} in-flight builds",
-            affectedLibraryIds, reason, removedMetadataCount, removedSortedListCount, removedBuildCount);
+            "Marked {MetadataCount} metadata, {SortedListCount} sorted-lists as dirty, {InFlightCount} in-flight builds.",
+            affectedLibraryIds, reason, dirtyMetadataCount, dirtySortedListCount, inFlightCount);
     }
 
-    // ── Build helpers ──────────────────────────────────────────────
+    // ── Background refresh helpers ────────────────────────────────
 
-    /// <summary>
-    /// Ensures only one build runs per sorted-list key. Stores metadata and sorted-list
-    /// snapshots atomically after the version check passes.
-    /// </summary>
-    private async Task<Result<MediaQueryBuildResult>> GetOrBuildSnapshotAsync(
-        MediaQueryFilter filter,
-        MediaQuerySortedListKey sortedListKey,
-        MediaSortNormalizer.Result sort,
-        CancellationToken cancellationToken)
+    private void QueueSnapshotRefresh(MediaQuerySortedListKey sortedListKey)
     {
-        var buildVersion = _buildVersions.GetOrAdd(sortedListKey, 0);
+        if (_builds.ContainsKey(sortedListKey))
+            return;
+
         var lazyBuild = _builds.GetOrAdd(
             sortedListKey,
             _ => new Lazy<Task<Result<MediaQueryBuildResult>>>(
-                () => BuildSnapshotAsync(filter, sortedListKey, sort, cancellationToken),
+                () => BuildAndStoreSnapshotAsync(sortedListKey, CancellationToken.None),
                 LazyThreadSafetyMode.ExecutionAndPublication));
 
+        _ = ObserveBuildAsync(lazyBuild, sortedListKey);
+    }
+
+    private async Task ObserveBuildAsync(
+        Lazy<Task<Result<MediaQueryBuildResult>>> lazyBuild,
+        MediaQuerySortedListKey sortedListKey)
+    {
         try
         {
-            var buildResult = await lazyBuild.Value;
-
-            if (_buildVersions.TryGetValue(sortedListKey, out var currentVersion) && currentVersion != buildVersion)
-                return Result.Fail("Media query cache build was invalidated before completion.");
-
-            if (buildResult.IsSuccess)
-            {
-                _metadataSnapshots[sortedListKey.MetadataKey] = buildResult.Value.Metadata;
-                _sortedListSnapshots[sortedListKey] = buildResult.Value.SortedList;
-            }
-
-            return buildResult;
+            _ = await lazyBuild.Value;
+        }
+        catch (Exception ex)
+        {
+            _log.Here().Error(ex, "Unhandled error in snapshot refresh background observer for {SortedListKey}", sortedListKey);
         }
         finally
         {
@@ -169,6 +183,51 @@ public sealed class MediaQueryCache : IMediaQueryCache
                 _builds.TryRemove(sortedListKey, out _);
         }
     }
+
+    private async Task<Result<MediaQueryBuildResult>> BuildAndStoreSnapshotAsync(
+        MediaQuerySortedListKey sortedListKey,
+        CancellationToken cancellationToken)
+    {
+        var libraryIds = sortedListKey.LibraryIds;
+        var plexLibraryId = libraryIds.Count == 1 ? libraryIds[0] : 0;
+        var filter = new MediaQueryFilter
+        {
+            MediaType = sortedListKey.MetadataKey.MediaType,
+            PlexLibraryId = plexLibraryId,
+            FilterOfflineMedia = sortedListKey.MetadataKey.FilterOfflineMedia,
+            FilterOwnedMedia = sortedListKey.MetadataKey.FilterOwnedMedia,
+            Parameters = new FlexQueryParameters { Sort = $"{sortedListKey.NormalizedAscendingSortField}:asc", Page = null, PageSize = null },
+        };
+
+        var sort = filter.Parameters.Sort.Normalize(libraryIds.Count);
+        if (sort is null)
+            return Result.Fail("Invalid sort parameter");
+
+        return await BuildAndStoreSnapshotAsync(filter, sortedListKey, cancellationToken);
+    }
+
+    private async Task<Result<MediaQueryBuildResult>> BuildAndStoreSnapshotAsync(
+        MediaQueryFilter filter,
+        MediaQuerySortedListKey sortedListKey,
+        CancellationToken cancellationToken)
+    {
+        var sort = MediaSortNormalizer.Normalize(filter.Parameters.Sort, 0);
+        if (sort is null)
+            return Result.Fail("Invalid sort parameter");
+
+        var buildResult = await BuildSnapshotAsync(filter, sortedListKey, sort, cancellationToken);
+
+        if (buildResult.IsSuccess)
+        {
+            _metadataSnapshots[sortedListKey.MetadataKey] = buildResult.Value.Metadata;
+            _sortedListSnapshots[sortedListKey] = buildResult.Value.SortedList;
+            _dirtyKeys.TryRemove(sortedListKey, out _);
+        }
+
+        return buildResult;
+    }
+
+
 
     /// <summary>
     /// Executes the media query with paging and user filters removed, producing both metadata
@@ -361,18 +420,30 @@ public sealed class MediaQueryCache : IMediaQueryCache
 
     // ── Invalidation helpers ───────────────────────────────────────
 
-    private static int RemoveKeysContainingLibrary<TKey, TValue>(
+    private int MarkKeysContainingLibraryAsDirty<TKey, TValue>(
         ConcurrentDictionary<TKey, TValue> dictionary,
         IReadOnlySet<int> libraryIds,
         Func<TKey, bool> matches)
         where TKey : notnull
     {
-        var keysToRemove = dictionary.Keys.Where(matches).ToList();
-        foreach (var key in keysToRemove)
-            dictionary.TryRemove(key, out _);
+        var matchingKeys = dictionary.Keys.Where(matches).ToList();
+        foreach (var key in matchingKeys)
+        {
+            if (key is MediaQuerySortedListKey sortedListKey)
+            {
+                _dirtyKeys.TryAdd(sortedListKey, true);
+                QueueSnapshotRefresh(sortedListKey);
+            }
+        }
 
-        return keysToRemove.Count;
+        return matchingKeys.Count;
     }
+
+    private static int CountKeysContainingLibrary<TKey, TValue>(
+        ConcurrentDictionary<TKey, TValue> dictionary,
+        IReadOnlySet<int> libraryIds,
+        Func<TKey, bool> matches)
+        where TKey : notnull => dictionary.Keys.Count(matches);
 
     // ── Factory helpers ────────────────────────────────────────────
 

--- a/src/Data/Cache/MediaQueryCache.cs
+++ b/src/Data/Cache/MediaQueryCache.cs
@@ -143,9 +143,9 @@ public sealed class MediaQueryCache : IMediaQueryCache
         if (affectedLibraryIds.Count == 0)
             return;
 
-        var dirtyMetadataCount = MarkKeysContainingLibraryAsDirty(_metadataSnapshots, affectedLibraryIds, k => k.ContainsAnyLibrary(affectedLibraryIds));
-        var dirtySortedListCount = MarkKeysContainingLibraryAsDirty(_sortedListSnapshots, affectedLibraryIds, k => k.ContainsAnyLibrary(affectedLibraryIds));
-        var inFlightCount = CountKeysContainingLibrary(_builds, affectedLibraryIds, k => k.ContainsAnyLibrary(affectedLibraryIds));
+        var dirtyMetadataCount = MarkKeysContainingLibraryAsDirty(_metadataSnapshots, k => k.ContainsAnyLibrary(affectedLibraryIds));
+        var dirtySortedListCount = MarkKeysContainingLibraryAsDirty(_sortedListSnapshots, k => k.ContainsAnyLibrary(affectedLibraryIds));
+        var inFlightCount = CountKeysContainingLibrary(_builds, k => k.ContainsAnyLibrary(affectedLibraryIds));
 
         _log.Here().Information(
             "Invalidated media query cache for libraries {PlexLibraryIds}: {Reason}. " +
@@ -215,7 +215,7 @@ public sealed class MediaQueryCache : IMediaQueryCache
         MediaQuerySortedListKey sortedListKey,
         CancellationToken cancellationToken)
     {
-        var sort = MediaSortNormalizer.Normalize(filter.Parameters.Sort, 0);
+        var sort = filter.Parameters.Sort.Normalize(sortedListKey.LibraryIds.Count);
         if (sort is null)
             return Result.Fail("Invalid sort parameter");
 
@@ -426,7 +426,6 @@ public sealed class MediaQueryCache : IMediaQueryCache
 
     private int MarkKeysContainingLibraryAsDirty<TKey, TValue>(
         ConcurrentDictionary<TKey, TValue> dictionary,
-        IReadOnlySet<int> libraryIds,
         Func<TKey, bool> matches)
         where TKey : notnull
     {
@@ -445,7 +444,6 @@ public sealed class MediaQueryCache : IMediaQueryCache
 
     private static int CountKeysContainingLibrary<TKey, TValue>(
         ConcurrentDictionary<TKey, TValue> dictionary,
-        IReadOnlySet<int> libraryIds,
         Func<TKey, bool> matches)
         where TKey : notnull => dictionary.Keys.Count(matches);
 

--- a/src/Data/Cache/MediaQueryCache.cs
+++ b/src/Data/Cache/MediaQueryCache.cs
@@ -160,10 +160,28 @@ public sealed class MediaQueryCache : IMediaQueryCache
         if (_builds.ContainsKey(sortedListKey))
             return;
 
+        var startVersion = _buildVersions.TryGetValue(sortedListKey, out var v) ? v : 0;
+
         var lazyBuild = _builds.GetOrAdd(
             sortedListKey,
             _ => new Lazy<Task<Result<MediaQueryBuildResult>>>(
-                () => BuildAndStoreSnapshotAsync(sortedListKey, CancellationToken.None),
+                async () =>
+                {
+                    var result = await BuildAndStoreSnapshotAsync(sortedListKey, CancellationToken.None);
+                    // If version was bumped during the build, the result may be stale.
+                    // Re-mark dirty so the next read queues a fresh build.
+                    if (result.IsSuccess
+                        && _buildVersions.TryGetValue(sortedListKey, out var currentVersion)
+                        && currentVersion > startVersion)
+                    {
+                        _dirtyKeys.TryAdd(sortedListKey, true);
+                        _log.Here().Debug(
+                            "Snapshot build for {SortedListKey} was stale (version {StartVersion} → {CurrentVersion}), re-marking dirty",
+                            sortedListKey, startVersion, currentVersion);
+                    }
+
+                    return result;
+                },
                 LazyThreadSafetyMode.ExecutionAndPublication));
 
         _ = ObserveBuildAsync(lazyBuild, sortedListKey);
@@ -185,6 +203,10 @@ public sealed class MediaQueryCache : IMediaQueryCache
         {
             if (_builds.TryGetValue(sortedListKey, out var currentBuild) && ReferenceEquals(currentBuild, lazyBuild))
                 _builds.TryRemove(sortedListKey, out _);
+
+            // If dirty marker survived the build (stale detection re-added it), queue another refresh.
+            if (_dirtyKeys.ContainsKey(sortedListKey))
+                QueueSnapshotRefresh(sortedListKey);
         }
     }
 
@@ -434,6 +456,7 @@ public sealed class MediaQueryCache : IMediaQueryCache
         {
             if (key is MediaQuerySortedListKey sortedListKey)
             {
+                _buildVersions.AddOrUpdate(sortedListKey, 1, (_, v) => v + 1);
                 _dirtyKeys.TryAdd(sortedListKey, true);
                 QueueSnapshotRefresh(sortedListKey);
             }

--- a/src/FileSystem.Contracts/_Shared/Extensions/IPathSystemExtensions.cs
+++ b/src/FileSystem.Contracts/_Shared/Extensions/IPathSystemExtensions.cs
@@ -9,7 +9,13 @@ public static class IPathExtensions
     {
         try
         {
-            var drive = path.FileSystem.DriveInfo.New(directory);
+            // On Windows, DriveInfo expects a drive root (C:\ or \\server\share), not a full path.
+            // UNC paths like \\server\share\subdir throw ArgumentException.
+            // On Linux/macOS, the full path works because DriveInfo resolves to the containing filesystem.
+            var drivePath = OperatingSystem.IsWindows()
+                ? Path.GetPathRoot(directory) ?? directory
+                : directory;
+            var drive = path.FileSystem.DriveInfo.New(drivePath);
             return Result.Ok(drive.AvailableFreeSpace);
         }
         catch (Exception e)

--- a/src/FluentResultExtensions/DTO/ResultDTOMapper.cs
+++ b/src/FluentResultExtensions/DTO/ResultDTOMapper.cs
@@ -84,6 +84,10 @@ public static class ResultDTOMapper
         if (result.Has504GatewayTimeoutError())
             return StatusCodes.Status504GatewayTimeout;
 
+        // Status Code 503 Service Unavailable
+        if (result.Has503ServiceUnavailableError())
+            return StatusCodes.Status503ServiceUnavailable;
+
         // Status Code 500 Internal Server Error
         return StatusCodes.Status500InternalServerError;
     }

--- a/src/FluentResultExtensions/ResultExtensions.WebApi.cs
+++ b/src/FluentResultExtensions/ResultExtensions.WebApi.cs
@@ -583,9 +583,9 @@ public static partial class ResultExtensions
         result.Errors.Any(error =>
             error.Message.Contains(NOT_ENOUGH_SPACE_TOKEN, StringComparison.OrdinalIgnoreCase)
             || error.Message.Contains(DISK_FULL_TOKEN, StringComparison.OrdinalIgnoreCase)
-            || error is ExceptionalError { Exception: IOException }
-            || error is ExceptionalError { Exception: UnauthorizedAccessException }
-        );
+        )
+        || result.HasException<IOException>()
+        || result.HasException<UnauthorizedAccessException>();
 
     public static bool HasStorageError<T>(this Result<T> result) =>
         result.ToResult().HasStorageError();

--- a/src/FluentResultExtensions/ResultExtensions.WebApi.cs
+++ b/src/FluentResultExtensions/ResultExtensions.WebApi.cs
@@ -573,4 +573,22 @@ public static partial class ResultExtensions
     #endregion
 
     #endregion
+
+    #region Storage
+
+    private const string NOT_ENOUGH_SPACE_TOKEN = "not enough space";
+    private const string DISK_FULL_TOKEN = "disk full";
+
+    public static bool HasStorageError(this Result result) =>
+        result.Errors.Any(error =>
+            error.Message.Contains(NOT_ENOUGH_SPACE_TOKEN, StringComparison.OrdinalIgnoreCase)
+            || error.Message.Contains(DISK_FULL_TOKEN, StringComparison.OrdinalIgnoreCase)
+            || error is ExceptionalError { Exception: IOException }
+            || error is ExceptionalError { Exception: UnauthorizedAccessException }
+        );
+
+    public static bool HasStorageError<T>(this Result<T> result) =>
+        result.ToResult().HasStorageError();
+
+    #endregion
 }

--- a/src/Logging/SlimLogConfig.cs
+++ b/src/Logging/SlimLogConfig.cs
@@ -52,7 +52,10 @@ public class SlimLogConfig
             .Enrich.FromLogContext();
 
         if (UseInteractiveSinks)
-            config = config.WriteTo.Debug(UseInteractiveSinks ? ConsoleTemplate : FileTemplate).WriteTo.Console(UseInteractiveSinks ? ConsoleTemplate : FileTemplate);
+        {
+            var template = Console.IsOutputRedirected ? FileTemplate : ConsoleTemplate;
+            config = config.WriteTo.Debug(template).WriteTo.Console(template);
+        }
 
         return config;
     }

--- a/src/PlexApi/PlexMedia/GetAllMediaByTypeFromPlexAPI/GetAllMediaByTypeFromPlexAPICommandHandler.cs
+++ b/src/PlexApi/PlexMedia/GetAllMediaByTypeFromPlexAPI/GetAllMediaByTypeFromPlexAPICommandHandler.cs
@@ -92,8 +92,9 @@ public class GetAllMediaByTypeFromPlexApiCommandHandler
             );
             if (mediaListResult.IsFailed)
             {
-                mediaListResult.ToResult().LogError();
-                return mediaListResult.ToResult();
+                var result = mediaListResult.ToResult();
+                result.LogError();
+                return result;
             }
 
             var rawMediaList = mediaListResult.Value;

--- a/src/PlexApi/PlexMedia/GetAllMediaByTypeFromPlexAPI/GetAllMediaByTypeFromPlexAPICommandHandler.cs
+++ b/src/PlexApi/PlexMedia/GetAllMediaByTypeFromPlexAPI/GetAllMediaByTypeFromPlexAPICommandHandler.cs
@@ -93,7 +93,7 @@ public class GetAllMediaByTypeFromPlexApiCommandHandler
             if (mediaListResult.IsFailed)
             {
                 mediaListResult.ToResult().LogError();
-                break;
+                return mediaListResult.ToResult();
             }
 
             var rawMediaList = mediaListResult.Value;

--- a/tests/UnitTests/Application.UnitTests/PlexMedia/WarmupMediaQueryCacheCommand.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexMedia/WarmupMediaQueryCacheCommand.UnitTests.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+
 namespace Reaparr.Application.UnitTests;
 
 public class WarmupMediaQueryCacheCommandHandlerUnitTests : BaseUnitTest<WarmupMediaQueryCacheCommandHandler>
@@ -9,9 +11,12 @@ public class WarmupMediaQueryCacheCommandHandlerUnitTests : BaseUnitTest<WarmupM
         await SetupDatabase(8237);
 
         Mock.Mock<IMediaQueryCache>()
+            .SetupProperty(x => x.SuppressInvalidation);
+        Mock.Mock<IMediaQueryCache>()
             .Setup(x => x.BuildCache())
-            .Returns(Task.CompletedTask)
-            .Verifiable(Times.Once());
+            .Returns(Task.CompletedTask);
+
+        OverrideSyncQuietPeriod(TimeSpan.Zero);
 
         // Act
         var result = await Sut.ExecuteAsync(new WarmupMediaQueryCacheCommand(), CancellationToken);
@@ -20,22 +25,29 @@ public class WarmupMediaQueryCacheCommandHandlerUnitTests : BaseUnitTest<WarmupM
         result.IsSuccess.ShouldBeTrue();
         result.Errors.Count.ShouldBe(0);
         Mock.Mock<IMediaQueryCache>().Verify(
+            x => x.BuildCache(),
+            Times.Exactly(2)
+        );
+        Mock.Mock<IMediaQueryCache>().Verify(
             x => x.GetMediaAsync(It.IsAny<MediaQueryFilter>(), It.IsAny<CancellationToken>()),
             Times.Never
         );
     }
 
     [Test]
-    public async Task ShouldReturnFailure_WhenMediaQueryCacheBuildFails()
+    public async Task ShouldReturnFailure_WhenFirstBuildFails()
     {
         // Arrange
         var expectedException = new InvalidOperationException("Build cache failed");
         await SetupDatabase(8237);
 
         Mock.Mock<IMediaQueryCache>()
+            .SetupProperty(x => x.SuppressInvalidation);
+        Mock.Mock<IMediaQueryCache>()
             .Setup(x => x.BuildCache())
-            .ThrowsAsync(expectedException)
-            .Verifiable(Times.Once());
+            .ThrowsAsync(expectedException);
+
+        OverrideSyncQuietPeriod(TimeSpan.Zero);
 
         // Act
         var result = await Sut.ExecuteAsync(new WarmupMediaQueryCacheCommand(), CancellationToken);
@@ -44,8 +56,43 @@ public class WarmupMediaQueryCacheCommandHandlerUnitTests : BaseUnitTest<WarmupM
         result.IsFailed.ShouldBeTrue();
         result.Errors.Count.ShouldBeGreaterThan(0);
         Mock.Mock<IMediaQueryCache>().Verify(
-            x => x.GetMediaAsync(It.IsAny<MediaQueryFilter>(), It.IsAny<CancellationToken>()),
-            Times.Never
+            x => x.BuildCache(),
+            Times.Once
         );
+    }
+
+    [Test]
+    public async Task ShouldSuppressInvalidationDuringSyncStorm_ThenUnsuppressAndRebuild()
+    {
+        // Arrange
+        await SetupDatabase(8237);
+
+        Mock.Mock<IMediaQueryCache>()
+            .SetupProperty(x => x.SuppressInvalidation);
+        Mock.Mock<IMediaQueryCache>()
+            .Setup(x => x.BuildCache())
+            .Returns(Task.CompletedTask);
+
+        OverrideSyncQuietPeriod(TimeSpan.Zero);
+
+        // Act
+        var result = await Sut.ExecuteAsync(new WarmupMediaQueryCacheCommand(), CancellationToken);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        var mock = Mock.Mock<IMediaQueryCache>();
+        mock.VerifySet(x => x.SuppressInvalidation = true, Times.Once);
+        mock.VerifySet(x => x.SuppressInvalidation = false, Times.Once);
+    }
+
+    /// <summary>
+    /// Overrides the quiet period to avoid real delays in unit tests.
+    /// </summary>
+    private void OverrideSyncQuietPeriod(TimeSpan period)
+    {
+        typeof(WarmupMediaQueryCacheCommandHandler)
+            .GetProperty("SyncQuietPeriod",
+                BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(Sut, period);
     }
 }

--- a/tests/UnitTests/Data.UnitTests/Cache/MediaQueryCache.UnitTests.cs
+++ b/tests/UnitTests/Data.UnitTests/Cache/MediaQueryCache.UnitTests.cs
@@ -6,158 +6,59 @@ namespace Reaparr.Data.UnitTests;
 
 public class MediaQueryCacheUnitTests : BaseUnitTest<MediaQueryCache>
 {
+    // ──────────────────────────────────────────────────────────────
+    // Cache miss → 503 (no synchronous blocking)
+    // ──────────────────────────────────────────────────────────────
+
     [Test]
-    public async Task ShouldReturnSecondPageItems_WhenUsingRealQueryHandlerSnapshot()
+    public async Task ShouldReturn503ServiceUnavailable_WhenCacheIsCold()
     {
         // Arrange
-        await SetupDatabase(70320, cfg =>
+        await SetupDatabase(70307, cfg =>
         {
             cfg.PlexServerCount = 1;
             cfg.PlexMovieLibraryCount = 1;
-            cfg.MovieCount = 250;
+            cfg.MovieCount = 5;
         });
 
-        var dbContext = IDbContext;
-        var allMovieIds = await dbContext.PlexMovies
-            .OrderBy(x => x.SearchTitle)
-            .Select(x => x.Id)
-            .ToListAsync(CancellationToken);
-        var filter = CreateFilter(sort: "sortIndex:asc", page: 2, pageSize: 100);
-        var realHandler = new GetMediaByTypeCommandHandler(dbContext);
-
-        Mock.Mock<ICommandExecutor>()
-            .Setup(x => x.Send(It.IsAny<GetMediaByTypeCommand>(), It.IsAny<CancellationToken>()))
-            .Returns<GetMediaByTypeCommand, CancellationToken>((command, token) => realHandler.ExecuteAsync(command, token))
-            .Verifiable(Times.Once());
+        var filter = CreateFilter(sort: "sortIndex:asc", page: 1, pageSize: 10);
 
         // Act
         var result = await Sut.GetMediaAsync(filter, CancellationToken);
 
         // Assert
-        result.IsSuccess.ShouldBeTrue();
-        result.Value.TotalCount.ShouldBe(allMovieIds.Count);
-        result.Value.Items.Select(x => x.Id).ShouldBe(allMovieIds.Skip(100).Take(100));
-        Mock.Mock<ICommandExecutor>().Verify();
+        result.IsFailed.ShouldBeTrue();
+        result.Errors.ShouldContain(x => x.Message.Contains("warming up"));
+        result.Has503ServiceUnavailableError().ShouldBeTrue();
     }
 
     [Test]
-    public async Task ShouldReturnDeepPageItems_WhenSnapshotContainsFullResult()
+    public async Task ShouldReturn503_WhenConcurrentRequestsMissSameSnapshot()
     {
         // Arrange
-        await SetupDatabase(70301, cfg =>
-        {
-            cfg.PlexServerCount = 1;
-            cfg.PlexMovieLibraryCount = 1;
-            cfg.MovieCount = 250;
-        });
-
-        var dbContext = IDbContext;
-        var allMovieIds = await dbContext.PlexMovies
-            .OrderBy(x => x.SearchTitle)
-            .Select(x => x.Id)
-            .ToListAsync(CancellationToken);
-        var expectedPageIds = allMovieIds.Skip(200).Take(50).ToList();
-
-        GetMediaByTypeCommand? capturedCommand = null;
-        var commandExecutor = Mock.Mock<ICommandExecutor>();
-        commandExecutor
-            .Setup(x => x.Send(It.IsAny<GetMediaByTypeCommand>(), It.IsAny<CancellationToken>()))
-            .Returns<GetMediaByTypeCommand, CancellationToken>((command, _) =>
-            {
-                capturedCommand = command;
-                return Task.FromResult(Result.Ok(CreateResult(allMovieIds)));
-            })
-            .Verifiable(Times.Once());
-
-        var filter = CreateFilter(sort: "sortIndex:asc", page: 5, pageSize: 50);
-
-        // Act
-        var result = await Sut.GetMediaAsync(filter, CancellationToken);
-
-        // Assert
-        result.IsSuccess.ShouldBeTrue();
-        result.Value.TotalCount.ShouldBe(allMovieIds.Count);
-        capturedCommand.ShouldNotBeNull();
-        capturedCommand!.Filter.Parameters.Page.ShouldBeNull();
-        capturedCommand.Filter.Parameters.PageSize.ShouldBeNull();
-        result.Value.Items.Count.ShouldBe(50);
-        result.Value.Items.Select(x => x.Id).ShouldBe(expectedPageIds);
-        result.Value.Items.Select(x => x.SortIndex).ShouldBe(Enumerable.Range(201, 50));
-        commandExecutor.Verify();
-    }
-
-    [Test]
-    public async Task ShouldReuseCachedSnapshot_WhenOnlyPageChanges()
-    {
-        // Arrange
-        await SetupDatabase(70302, cfg =>
+        await SetupDatabase(70315, cfg =>
         {
             cfg.PlexServerCount = 1;
             cfg.PlexMovieLibraryCount = 1;
             cfg.MovieCount = 30;
         });
 
-        var allMovieIds = await IDbContext.PlexMovies
-            .OrderBy(x => x.SearchTitle)
-            .Select(x => x.Id)
-            .ToListAsync(CancellationToken);
-        var firstPageFilter = CreateFilter(sort: "sortIndex:asc", page: 1, pageSize: 10);
-        var secondPageFilter = CreateFilter(sort: "sortIndex:asc", page: 2, pageSize: 10);
-
-        var commandExecutor = Mock.Mock<ICommandExecutor>();
-        commandExecutor
-            .Setup(x => x.Send(It.IsAny<GetMediaByTypeCommand>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Result.Ok(CreateResult(allMovieIds)))
-            .Verifiable(Times.Once());
+        var firstFilter = CreateFilter(sort: "sortIndex:asc", page: 1, pageSize: 5);
+        var secondFilter = CreateFilter(sort: "sortIndex:asc", page: 2, pageSize: 5);
 
         // Act
-        var firstResult = await Sut.GetMediaAsync(firstPageFilter, CancellationToken);
-        var secondResult = await Sut.GetMediaAsync(secondPageFilter, CancellationToken);
+        var results = await Task.WhenAll(
+            Sut.GetMediaAsync(firstFilter, CancellationToken),
+            Sut.GetMediaAsync(secondFilter, CancellationToken));
 
         // Assert
-        firstResult.IsSuccess.ShouldBeTrue();
-        secondResult.IsSuccess.ShouldBeTrue();
-        firstResult.Value.Items.Select(x => x.Id).ShouldBe(allMovieIds.Take(10));
-        secondResult.Value.Items.Select(x => x.Id).ShouldBe(allMovieIds.Skip(10).Take(10));
-        commandExecutor.Verify();
+        results.ShouldAllBe(x => x.IsFailed);
+        results.ShouldAllBe(x => x.Has503ServiceUnavailableError());
     }
 
-    [Test]
-    public async Task ShouldReuseAscendingSnapshotAndReverseItems_WhenDescendingSortRequested()
-    {
-        // Arrange
-        await SetupDatabase(70303, cfg =>
-        {
-            cfg.PlexServerCount = 1;
-            cfg.PlexMovieLibraryCount = 1;
-            cfg.MovieCount = 25;
-        });
-
-        var allMovieIds = await IDbContext.PlexMovies
-            .OrderBy(x => x.SearchTitle)
-            .Select(x => x.Id)
-            .ToListAsync(CancellationToken);
-        var ascendingFilter = CreateFilter(sort: "sortIndex:asc", page: 1, pageSize: 5);
-        var descendingFilter = CreateFilter(sort: "sortIndex:desc", page: 1, pageSize: 5);
-
-        var commandExecutor = Mock.Mock<ICommandExecutor>();
-        commandExecutor
-            .Setup(x => x.Send(It.IsAny<GetMediaByTypeCommand>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Result.Ok(CreateResult(allMovieIds)))
-            .Verifiable(Times.Once());
-
-        // Act
-        var ascendingResult = await Sut.GetMediaAsync(ascendingFilter, CancellationToken);
-        var descendingResult = await Sut.GetMediaAsync(descendingFilter, CancellationToken);
-
-        // Assert
-        ascendingResult.IsSuccess.ShouldBeTrue();
-        descendingResult.IsSuccess.ShouldBeTrue();
-        ascendingResult.Value.Items.Select(x => x.Id).ShouldBe(allMovieIds.Take(5));
-        descendingResult.Value.Items.Select(x => x.Id).ShouldBe(allMovieIds.AsEnumerable().Reverse().Take(5));
-        descendingResult.Value.Items.Select(x => x.SortIndex).ShouldBe(Enumerable.Range(1, 5));
-        commandExecutor.Verify();
-    }
+    // ──────────────────────────────────────────────────────────────
+    // Cache bypass (query/filter/multi-sort still work directly)
+    // ──────────────────────────────────────────────────────────────
 
     [Test]
     public async Task ShouldBypassCache_WhenQueryParameterIsSet()
@@ -173,8 +74,7 @@ public class MediaQueryCacheUnitTests : BaseUnitTest<MediaQueryCache>
         var filter = CreateFilter(query: "alpha", sort: "sortIndex:asc", page: 2, pageSize: 2);
         GetMediaByTypeCommand? capturedCommand = null;
 
-        var commandExecutor = Mock.Mock<ICommandExecutor>();
-        commandExecutor
+        Mock.Mock<ICommandExecutor>()
             .Setup(x => x.Send(It.IsAny<GetMediaByTypeCommand>(), It.IsAny<CancellationToken>()))
             .Returns<GetMediaByTypeCommand, CancellationToken>((command, _) =>
             {
@@ -188,12 +88,10 @@ public class MediaQueryCacheUnitTests : BaseUnitTest<MediaQueryCache>
 
         // Assert
         result.IsSuccess.ShouldBeTrue();
-        capturedCommand.ShouldNotBeNull();
         capturedCommand!.Filter.Parameters.Query.ShouldBe("alpha");
         capturedCommand.Filter.Parameters.Page.ShouldBe(2);
-        capturedCommand.Filter.Parameters.PageSize.ShouldBe(2);
         result.Value.Items.Select(x => x.Id).ShouldBe([101, 102]);
-        commandExecutor.Verify();
+        Mock.Mock<ICommandExecutor>().Verify();
     }
 
     [Test]
@@ -210,8 +108,7 @@ public class MediaQueryCacheUnitTests : BaseUnitTest<MediaQueryCache>
         var filter = CreateFilter(filter: "Genres:any:Id:eq:1", sort: "sortIndex:asc", page: 3, pageSize: 2);
         GetMediaByTypeCommand? capturedCommand = null;
 
-        var commandExecutor = Mock.Mock<ICommandExecutor>();
-        commandExecutor
+        Mock.Mock<ICommandExecutor>()
             .Setup(x => x.Send(It.IsAny<GetMediaByTypeCommand>(), It.IsAny<CancellationToken>()))
             .Returns<GetMediaByTypeCommand, CancellationToken>((command, _) =>
             {
@@ -225,12 +122,10 @@ public class MediaQueryCacheUnitTests : BaseUnitTest<MediaQueryCache>
 
         // Assert
         result.IsSuccess.ShouldBeTrue();
-        capturedCommand.ShouldNotBeNull();
         capturedCommand!.Filter.Parameters.Filter.ShouldBe("Genres:any:Id:eq:1");
         capturedCommand.Filter.Parameters.Page.ShouldBe(3);
-        capturedCommand.Filter.Parameters.PageSize.ShouldBe(2);
         result.Value.Items.Select(x => x.Id).ShouldBe([201, 202]);
-        commandExecutor.Verify();
+        Mock.Mock<ICommandExecutor>().Verify();
     }
 
     [Test]
@@ -247,8 +142,7 @@ public class MediaQueryCacheUnitTests : BaseUnitTest<MediaQueryCache>
         var filter = CreateFilter(sort: "year:asc,title:desc", page: 4, pageSize: 2);
         GetMediaByTypeCommand? capturedCommand = null;
 
-        var commandExecutor = Mock.Mock<ICommandExecutor>();
-        commandExecutor
+        Mock.Mock<ICommandExecutor>()
             .Setup(x => x.Send(It.IsAny<GetMediaByTypeCommand>(), It.IsAny<CancellationToken>()))
             .Returns<GetMediaByTypeCommand, CancellationToken>((command, _) =>
             {
@@ -262,331 +156,16 @@ public class MediaQueryCacheUnitTests : BaseUnitTest<MediaQueryCache>
 
         // Assert
         result.IsSuccess.ShouldBeTrue();
-        capturedCommand.ShouldNotBeNull();
         capturedCommand!.Filter.Parameters.Sort.ShouldBe("year:asc,title:desc");
         capturedCommand.Filter.Parameters.Page.ShouldBe(4);
-        capturedCommand.Filter.Parameters.PageSize.ShouldBe(2);
         result.Value.Items.Select(x => x.Id).ShouldBe([301, 302]);
-        commandExecutor.Verify();
+        Mock.Mock<ICommandExecutor>().Verify();
     }
 
-    [Test]
-    public async Task ShouldReturnFailure_WhenSnapshotBuildCommandFails()
-    {
-        // Arrange
-        await SetupDatabase(70307, cfg =>
-        {
-            cfg.PlexServerCount = 1;
-            cfg.PlexMovieLibraryCount = 1;
-            cfg.MovieCount = 5;
-        });
-
-        var filter = CreateFilter(sort: "sortIndex:asc", page: 1, pageSize: 10);
-
-        var commandExecutor = Mock.Mock<ICommandExecutor>();
-        commandExecutor
-            .Setup(x => x.Send(It.IsAny<GetMediaByTypeCommand>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Result.Fail<PagedMediaQueryResult>("snapshot build failed"))
-            .Verifiable(Times.Once());
-
-        // Act
-        var result = await Sut.GetMediaAsync(filter, CancellationToken);
-
-        // Assert
-        result.IsFailed.ShouldBeTrue();
-        result.Errors.ShouldContain(x => x.Message == "snapshot build failed");
-        commandExecutor.Verify();
-    }
-
-    [Test]
-    public async Task ShouldNormalizeAllLibrarySortIndexToSearchTitle_WhenMultipleLibrariesAreInScope()
-    {
-        // Arrange
-        await SetupDatabase(70308, cfg =>
-        {
-            cfg.PlexServerCount = 1;
-            cfg.PlexMovieLibraryCount = 2;
-            cfg.MovieCount = 5;
-        });
-
-        var filter = CreateFilter(sort: "sortIndex:asc", page: 1, pageSize: 5);
-        GetMediaByTypeCommand? capturedCommand = null;
-
-        var commandExecutor = Mock.Mock<ICommandExecutor>();
-        commandExecutor
-            .Setup(x => x.Send(It.IsAny<GetMediaByTypeCommand>(), It.IsAny<CancellationToken>()))
-            .Returns<GetMediaByTypeCommand, CancellationToken>((command, _) =>
-            {
-                capturedCommand = command;
-                return Task.FromResult(Result.Ok(CreateResult([1, 2, 3, 4, 5])));
-            })
-            .Verifiable(Times.Once());
-
-        // Act
-        var result = await Sut.GetMediaAsync(filter, CancellationToken);
-
-        // Assert
-        result.IsSuccess.ShouldBeTrue();
-        capturedCommand.ShouldNotBeNull();
-        capturedCommand!.Filter.Parameters.Sort.ShouldBe("SearchTitle:asc");
-        capturedCommand.Filter.Parameters.Page.ShouldBeNull();
-        capturedCommand.Filter.Parameters.PageSize.ShouldBeNull();
-        commandExecutor.Verify();
-    }
-
-    [Test]
-    public async Task ShouldKeepSortIndexSort_WhenSingleSpecificLibraryIsInScope()
-    {
-        // Arrange
-        await SetupDatabase(70309, cfg =>
-        {
-            cfg.PlexServerCount = 1;
-            cfg.PlexMovieLibraryCount = 1;
-            cfg.MovieCount = 5;
-        });
-
-        var libraryId = await IDbContext.PlexLibraries
-            .Where(x => x.Type == PlexMediaType.Movie)
-            .Select(x => x.Id)
-            .FirstAsync(CancellationToken);
-        var filter = CreateFilter(plexLibraryId: libraryId, sort: "sortIndex:asc", page: 1, pageSize: 5);
-        GetMediaByTypeCommand? capturedCommand = null;
-
-        var commandExecutor = Mock.Mock<ICommandExecutor>();
-        commandExecutor
-            .Setup(x => x.Send(It.IsAny<GetMediaByTypeCommand>(), It.IsAny<CancellationToken>()))
-            .Returns<GetMediaByTypeCommand, CancellationToken>((command, _) =>
-            {
-                capturedCommand = command;
-                return Task.FromResult(Result.Ok(CreateResult([1, 2, 3, 4, 5])));
-            })
-            .Verifiable(Times.Once());
-
-        // Act
-        var result = await Sut.GetMediaAsync(filter, CancellationToken);
-
-        // Assert
-        result.IsSuccess.ShouldBeTrue();
-        capturedCommand.ShouldNotBeNull();
-        capturedCommand!.Filter.Parameters.Sort.ShouldBe("sortIndex:asc");
-        capturedCommand.Filter.Parameters.Page.ShouldBeNull();
-        capturedCommand.Filter.Parameters.PageSize.ShouldBeNull();
-        commandExecutor.Verify();
-    }
-
-    [Test]
-    public async Task ShouldUseSearchTitleDefaultSort_WhenAllLibraryModeHasMultipleLibraries()
-    {
-        // Arrange
-        await SetupDatabase(70310, cfg =>
-        {
-            cfg.PlexServerCount = 1;
-            cfg.PlexMovieLibraryCount = 2;
-            cfg.MovieCount = 5;
-        });
-
-        var filter = CreateFilter(sort: null, page: 1, pageSize: 5);
-        GetMediaByTypeCommand? capturedCommand = null;
-
-        var commandExecutor = Mock.Mock<ICommandExecutor>();
-        commandExecutor
-            .Setup(x => x.Send(It.IsAny<GetMediaByTypeCommand>(), It.IsAny<CancellationToken>()))
-            .Returns<GetMediaByTypeCommand, CancellationToken>((command, _) =>
-            {
-                capturedCommand = command;
-                return Task.FromResult(Result.Ok(CreateResult([1, 2, 3, 4, 5])));
-            })
-            .Verifiable(Times.Once());
-
-        // Act
-        var result = await Sut.GetMediaAsync(filter, CancellationToken);
-
-        // Assert
-        result.IsSuccess.ShouldBeTrue();
-        capturedCommand.ShouldNotBeNull();
-        capturedCommand!.Filter.Parameters.Sort.ShouldBe("SearchTitle:asc");
-        commandExecutor.Verify();
-    }
-
-    [Test]
-    public async Task ShouldUseSortIndexDefaultSort_WhenSingleLibraryIsInScope()
-    {
-        // Arrange
-        await SetupDatabase(70311, cfg =>
-        {
-            cfg.PlexServerCount = 1;
-            cfg.PlexMovieLibraryCount = 1;
-            cfg.MovieCount = 5;
-        });
-
-        var filter = CreateFilter(sort: null, page: 1, pageSize: 5);
-        GetMediaByTypeCommand? capturedCommand = null;
-
-        var commandExecutor = Mock.Mock<ICommandExecutor>();
-        commandExecutor
-            .Setup(x => x.Send(It.IsAny<GetMediaByTypeCommand>(), It.IsAny<CancellationToken>()))
-            .Returns<GetMediaByTypeCommand, CancellationToken>((command, _) =>
-            {
-                capturedCommand = command;
-                return Task.FromResult(Result.Ok(CreateResult([1, 2, 3, 4, 5])));
-            })
-            .Verifiable(Times.Once());
-
-        // Act
-        var result = await Sut.GetMediaAsync(filter, CancellationToken);
-
-        // Assert
-        result.IsSuccess.ShouldBeTrue();
-        capturedCommand.ShouldNotBeNull();
-        capturedCommand!.Filter.Parameters.Sort.ShouldBe("sortIndex:asc");
-        commandExecutor.Verify();
-    }
-
-    [Test]
-    public async Task ShouldReturnAllItems_WhenRequestedPageSizeIsNull()
-    {
-        // Arrange
-        await SetupDatabase(70312, cfg =>
-        {
-            cfg.PlexServerCount = 1;
-            cfg.PlexMovieLibraryCount = 1;
-            cfg.MovieCount = 12;
-        });
-
-        var allMovieIds = await IDbContext.PlexMovies
-            .OrderBy(x => x.SearchTitle)
-            .Select(x => x.Id)
-            .ToListAsync(CancellationToken);
-        var filter = CreateFilter(sort: "sortIndex:asc", page: null, pageSize: null);
-
-        var commandExecutor = Mock.Mock<ICommandExecutor>();
-        commandExecutor
-            .Setup(x => x.Send(It.IsAny<GetMediaByTypeCommand>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Result.Ok(CreateResult(allMovieIds)))
-            .Verifiable(Times.Once());
-
-        // Act
-        var result = await Sut.GetMediaAsync(filter, CancellationToken);
-
-        // Assert
-        result.IsSuccess.ShouldBeTrue();
-        result.Value.Page.ShouldBe(1);
-        result.Value.PageSize.ShouldBe(allMovieIds.Count);
-        result.Value.Items.Select(x => x.Id).ShouldBe(allMovieIds);
-        commandExecutor.Verify();
-    }
-
-    [Test]
-    public async Task ShouldReturnEmptyItemsWithMetadata_WhenRequestedPageIsBeyondSnapshotRange()
-    {
-        // Arrange
-        await SetupDatabase(70313, cfg =>
-        {
-            cfg.PlexServerCount = 1;
-            cfg.PlexMovieLibraryCount = 1;
-            cfg.MovieCount = 12;
-        });
-
-        var allMovieIds = await IDbContext.PlexMovies
-            .OrderBy(x => x.SearchTitle)
-            .Select(x => x.Id)
-            .ToListAsync(CancellationToken);
-        var filter = CreateFilter(sort: "sortIndex:asc", page: 99, pageSize: 10);
-
-        var commandExecutor = Mock.Mock<ICommandExecutor>();
-        commandExecutor
-            .Setup(x => x.Send(It.IsAny<GetMediaByTypeCommand>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Result.Ok(CreateResult(allMovieIds, totalMediaSize: 12345)))
-            .Verifiable(Times.Once());
-
-        // Act
-        var result = await Sut.GetMediaAsync(filter, CancellationToken);
-
-        // Assert
-        result.IsSuccess.ShouldBeTrue();
-        result.Value.Page.ShouldBe(99);
-        result.Value.PageSize.ShouldBe(10);
-        result.Value.TotalCount.ShouldBe(allMovieIds.Count);
-        result.Value.MediaSize.ShouldBe(12345);
-        result.Value.Items.ShouldBeEmpty();
-        commandExecutor.Verify();
-    }
-
-    [Test]
-    public async Task ShouldUseSeparateSnapshots_WhenVisibilityFiltersChange()
-    {
-        // Arrange
-        await SetupDatabase(70314, cfg =>
-        {
-            cfg.PlexServerCount = 1;
-            cfg.PlexMovieLibraryCount = 1;
-            cfg.MovieCount = 10;
-        });
-
-        var unfiltered = CreateFilter(sort: "sortIndex:asc", page: 1, pageSize: 5);
-        var filtered = CreateFilter(filterOfflineMedia: true, filterOwnedMedia: true, sort: "sortIndex:asc", page: 1,
-            pageSize: 5);
-        var buildResults = new Queue<Result<PagedMediaQueryResult>>([
-            Result.Ok(CreateResult([1, 2, 3, 4, 5])),
-            Result.Ok(CreateResult([6, 7, 8, 9, 10])),
-        ]);
-
-        var commandExecutor = Mock.Mock<ICommandExecutor>();
-        commandExecutor
-            .Setup(x => x.Send(It.IsAny<GetMediaByTypeCommand>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(() => buildResults.Dequeue())
-            .Verifiable(Times.Exactly(2));
-
-        // Act
-        var unfilteredResult = await Sut.GetMediaAsync(unfiltered, CancellationToken);
-        var filteredResult = await Sut.GetMediaAsync(filtered, CancellationToken);
-
-        // Assert
-        unfilteredResult.IsSuccess.ShouldBeTrue();
-        filteredResult.IsSuccess.ShouldBeTrue();
-        unfilteredResult.Value.Items.Select(x => x.Id).ShouldBe([1, 2, 3, 4, 5]);
-        filteredResult.Value.Items.Select(x => x.Id).ShouldBe([6, 7, 8, 9, 10]);
-        commandExecutor.Verify();
-    }
-
-    [Test]
-    public async Task ShouldShareSingleBuild_WhenConcurrentRequestsMissSameSnapshot()
-    {
-        // Arrange
-        await SetupDatabase(70315, cfg =>
-        {
-            cfg.PlexServerCount = 1;
-            cfg.PlexMovieLibraryCount = 1;
-            cfg.MovieCount = 30;
-        });
-
-        var allMovieIds = await IDbContext.PlexMovies
-            .OrderBy(x => x.SearchTitle)
-            .Select(x => x.Id)
-            .ToListAsync(CancellationToken);
-        var firstFilter = CreateFilter(sort: "sortIndex:asc", page: 1, pageSize: 5);
-        var secondFilter = CreateFilter(sort: "sortIndex:asc", page: 2, pageSize: 5);
-        var buildCompletion =
-            new TaskCompletionSource<Result<PagedMediaQueryResult>>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        var commandExecutor = Mock.Mock<ICommandExecutor>();
-        commandExecutor
-            .Setup(x => x.Send(It.IsAny<GetMediaByTypeCommand>(), It.IsAny<CancellationToken>()))
-            .Returns(buildCompletion.Task)
-            .Verifiable(Times.Once());
-
-        // Act
-        var firstTask = Sut.GetMediaAsync(firstFilter, CancellationToken);
-        var secondTask = Sut.GetMediaAsync(secondFilter, CancellationToken);
-        buildCompletion.SetResult(Result.Ok(CreateResult(allMovieIds)));
-        var results = await Task.WhenAll(firstTask, secondTask);
-
-        // Assert
-        results.ShouldAllBe(x => x.IsSuccess);
-        results[0].Value.Items.Select(x => x.Id).ShouldBe(allMovieIds.Take(5));
-        results[1].Value.Items.Select(x => x.Id).ShouldBe(allMovieIds.Skip(5).Take(5));
-        commandExecutor.Verify();
-    }
+    // ──────────────────────────────────────────────────────────────
+    // BuildCache warms all-library snapshots synchronously.
+    // Subsequent all-library requests hit the cache.
+    // ──────────────────────────────────────────────────────────────
 
     [Test]
     public async Task ShouldWarmAllLibraryMovieAndTvShowSnapshots_WhenBuildCacheRuns()
@@ -602,8 +181,8 @@ public class MediaQueryCacheUnitTests : BaseUnitTest<MediaQueryCache>
         });
 
         var capturedCommands = new List<GetMediaByTypeCommand>();
-        var commandExecutor = Mock.Mock<ICommandExecutor>();
-        commandExecutor
+
+        Mock.Mock<ICommandExecutor>()
             .Setup(x => x.Send(It.IsAny<GetMediaByTypeCommand>(), It.IsAny<CancellationToken>()))
             .Returns<GetMediaByTypeCommand, CancellationToken>((command, _) =>
             {
@@ -623,17 +202,224 @@ public class MediaQueryCacheUnitTests : BaseUnitTest<MediaQueryCache>
         capturedCommands.Select(x => x.Filter.MediaType).Count(x => x == PlexMediaType.Movie).ShouldBe(7);
         capturedCommands.Select(x => x.Filter.MediaType).Count(x => x == PlexMediaType.TvShow).ShouldBe(7);
         capturedCommands.ShouldAllBe(x => x.Filter.PlexLibraryId == 0);
-        foreach (var command in capturedCommands)
-        {
-            command.Filter.Parameters.Page.ShouldBeNull();
-            command.Filter.Parameters.PageSize.ShouldBeNull();
-        }
-
-        commandExecutor.Verify();
+        capturedCommands.ShouldAllBe(x => x.Filter.Parameters.Page == null);
+        capturedCommands.ShouldAllBe(x => x.Filter.Parameters.PageSize == null);
+        Mock.Mock<ICommandExecutor>().Verify();
     }
 
     [Test]
-    public async Task ShouldTriggerFreshBuild_WhenInvalidationClearsCachedSnapshot()
+    public async Task ShouldHitWarmedCache_WhenRequestingAllLibraries()
+    {
+        // Arrange
+        await SetupDatabase(70302, cfg =>
+        {
+            cfg.PlexServerCount = 1;
+            cfg.PlexMovieLibraryCount = 1;
+            cfg.MovieCount = 30;
+        });
+
+        // Setup mocks for warmup
+        var allMovieIds = await IDbContext.PlexMovies
+            .OrderBy(x => x.SearchTitle)
+            .Select(x => x.Id)
+            .ToListAsync(CancellationToken);
+
+        Mock.Mock<IGeneralSettings>().Setup(x => x.HideMediaFromOfflineServers).Returns(false);
+        Mock.Mock<IGeneralSettings>().Setup(x => x.HideMediaFromOwnedServers).Returns(false);
+
+        Mock.Mock<ICommandExecutor>()
+            .Setup(x => x.Send(It.IsAny<GetMediaByTypeCommand>(), It.IsAny<CancellationToken>()))
+            .Returns<GetMediaByTypeCommand, CancellationToken>((command, _) =>
+                Task.FromResult(Result.Ok(CreateResult(allMovieIds, command.Filter.MediaType))));
+
+        await Sut.BuildCache();
+
+        // Reset and verify no more executor calls needed (cache hits)
+        Mock.Mock<ICommandExecutor>().Reset();
+
+        var firstPageFilter = CreateFilter(sort: "sortIndex:asc", page: 1, pageSize: 10);
+        var secondPageFilter = CreateFilter(sort: "sortIndex:asc", page: 2, pageSize: 10);
+
+        // Act
+        var firstResult = await Sut.GetMediaAsync(firstPageFilter, CancellationToken);
+        var secondResult = await Sut.GetMediaAsync(secondPageFilter, CancellationToken);
+
+        // Assert
+        firstResult.IsSuccess.ShouldBeTrue();
+        secondResult.IsSuccess.ShouldBeTrue();
+        firstResult.Value.Items.Select(x => x.Id).ShouldBe(allMovieIds.Take(10));
+        secondResult.Value.Items.Select(x => x.Id).ShouldBe(allMovieIds.Skip(10).Take(10));
+    }
+
+    [Test]
+    public async Task ShouldReuseAscendingSnapshotAndReverseItems_WhenDescendingSortRequested()
+    {
+        // Arrange
+        await SetupDatabase(70303, cfg =>
+        {
+            cfg.PlexServerCount = 1;
+            cfg.PlexMovieLibraryCount = 1;
+            cfg.MovieCount = 25;
+        });
+
+        var allMovieIds = await IDbContext.PlexMovies
+            .OrderBy(x => x.SearchTitle)
+            .Select(x => x.Id)
+            .ToListAsync(CancellationToken);
+
+        Mock.Mock<IGeneralSettings>().Setup(x => x.HideMediaFromOfflineServers).Returns(false);
+        Mock.Mock<IGeneralSettings>().Setup(x => x.HideMediaFromOwnedServers).Returns(false);
+
+        Mock.Mock<ICommandExecutor>()
+            .Setup(x => x.Send(It.IsAny<GetMediaByTypeCommand>(), It.IsAny<CancellationToken>()))
+            .Returns<GetMediaByTypeCommand, CancellationToken>((command, _) =>
+                Task.FromResult(Result.Ok(CreateResult(allMovieIds, command.Filter.MediaType))));
+
+        await Sut.BuildCache();
+
+        Mock.Mock<ICommandExecutor>().Reset();
+
+        var ascendingFilter = CreateFilter(sort: "sortIndex:asc", page: 1, pageSize: 5);
+        var descendingFilter = CreateFilter(sort: "sortIndex:desc", page: 1, pageSize: 5);
+
+        // Act
+        var ascendingResult = await Sut.GetMediaAsync(ascendingFilter, CancellationToken);
+        var descendingResult = await Sut.GetMediaAsync(descendingFilter, CancellationToken);
+
+        // Assert
+        ascendingResult.IsSuccess.ShouldBeTrue();
+        descendingResult.IsSuccess.ShouldBeTrue();
+        ascendingResult.Value.Items.Select(x => x.Id).ShouldBe(allMovieIds.Take(5));
+        descendingResult.Value.Items.Select(x => x.Id).ShouldBe(allMovieIds.AsEnumerable().Reverse().Take(5));
+        descendingResult.Value.Items.Select(x => x.SortIndex).ShouldBe(Enumerable.Range(1, 5));
+    }
+
+    [Test]
+    public async Task ShouldReturnEmptyItemsWithMetadata_WhenRequestedPageIsBeyondSnapshotRange()
+    {
+        // Arrange
+        await SetupDatabase(70313, cfg =>
+        {
+            cfg.PlexServerCount = 1;
+            cfg.PlexMovieLibraryCount = 1;
+            cfg.MovieCount = 12;
+        });
+
+        var allMovieIds = await IDbContext.PlexMovies
+            .OrderBy(x => x.SearchTitle)
+            .Select(x => x.Id)
+            .ToListAsync(CancellationToken);
+
+        Mock.Mock<IGeneralSettings>().Setup(x => x.HideMediaFromOfflineServers).Returns(false);
+        Mock.Mock<IGeneralSettings>().Setup(x => x.HideMediaFromOwnedServers).Returns(false);
+
+        Mock.Mock<ICommandExecutor>()
+            .Setup(x => x.Send(It.IsAny<GetMediaByTypeCommand>(), It.IsAny<CancellationToken>()))
+            .Returns<GetMediaByTypeCommand, CancellationToken>((command, _) =>
+                Task.FromResult(Result.Ok(CreateResult(allMovieIds, command.Filter.MediaType, totalMediaSize: 12345))));
+
+        await Sut.BuildCache();
+        Mock.Mock<ICommandExecutor>().Reset();
+
+        var filter = CreateFilter(sort: "sortIndex:asc", page: 99, pageSize: 10);
+
+        // Act
+        var result = await Sut.GetMediaAsync(filter, CancellationToken);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Page.ShouldBe(99);
+        result.Value.PageSize.ShouldBe(10);
+        result.Value.TotalCount.ShouldBe(allMovieIds.Count);
+        result.Value.MediaSize.ShouldBe(12345);
+        result.Value.Items.ShouldBeEmpty();
+    }
+
+    [Test]
+    public async Task ShouldReturnAllItems_WhenRequestedPageSizeIsNull()
+    {
+        // Arrange
+        await SetupDatabase(70312, cfg =>
+        {
+            cfg.PlexServerCount = 1;
+            cfg.PlexMovieLibraryCount = 1;
+            cfg.MovieCount = 12;
+        });
+
+        var allMovieIds = await IDbContext.PlexMovies
+            .OrderBy(x => x.SearchTitle)
+            .Select(x => x.Id)
+            .ToListAsync(CancellationToken);
+
+        Mock.Mock<IGeneralSettings>().Setup(x => x.HideMediaFromOfflineServers).Returns(false);
+        Mock.Mock<IGeneralSettings>().Setup(x => x.HideMediaFromOwnedServers).Returns(false);
+
+        Mock.Mock<ICommandExecutor>()
+            .Setup(x => x.Send(It.IsAny<GetMediaByTypeCommand>(), It.IsAny<CancellationToken>()))
+            .Returns<GetMediaByTypeCommand, CancellationToken>((command, _) =>
+                Task.FromResult(Result.Ok(CreateResult(allMovieIds, command.Filter.MediaType))));
+
+        await Sut.BuildCache();
+        Mock.Mock<ICommandExecutor>().Reset();
+
+        var filter = CreateFilter(sort: "sortIndex:asc", page: null, pageSize: null);
+
+        // Act
+        var result = await Sut.GetMediaAsync(filter, CancellationToken);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Page.ShouldBe(1);
+        result.Value.PageSize.ShouldBe(allMovieIds.Count);
+        result.Value.Items.Select(x => x.Id).ShouldBe(allMovieIds);
+    }
+
+    [Test]
+    public async Task ShouldReturnEmptyFilterArrays_InPageResponse()
+    {
+        // Arrange
+        await SetupDatabase(70320, cfg =>
+        {
+            cfg.PlexServerCount = 1;
+            cfg.PlexMovieLibraryCount = 1;
+            cfg.MovieCount = 10;
+        });
+
+        var allMovieIds = await IDbContext.PlexMovies
+            .OrderBy(x => x.SearchTitle)
+            .Select(x => x.Id)
+            .ToListAsync(CancellationToken);
+
+        Mock.Mock<IGeneralSettings>().Setup(x => x.HideMediaFromOfflineServers).Returns(false);
+        Mock.Mock<IGeneralSettings>().Setup(x => x.HideMediaFromOwnedServers).Returns(false);
+
+        Mock.Mock<ICommandExecutor>()
+            .Setup(x => x.Send(It.IsAny<GetMediaByTypeCommand>(), It.IsAny<CancellationToken>()))
+            .Returns<GetMediaByTypeCommand, CancellationToken>((command, _) =>
+                Task.FromResult(Result.Ok(CreateResult(allMovieIds, command.Filter.MediaType))));
+
+        await Sut.BuildCache();
+        Mock.Mock<ICommandExecutor>().Reset();
+
+        var filter = CreateFilter(sort: "sortIndex:asc", page: 1, pageSize: 5);
+
+        // Act
+        var result = await Sut.GetMediaAsync(filter, CancellationToken);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Roles.ShouldBeEmpty();
+        result.Value.Countries.ShouldBeEmpty();
+        result.Value.Genres.ShouldBeEmpty();
+        result.Value.Qualities.ShouldBeEmpty();
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Invalidation: marks dirty, returns stale, queues background
+    // ──────────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task ShouldReturnStaleData_WhenInvalidationMarksSnapshotDirty()
     {
         // Arrange
         await SetupDatabase(70317, cfg =>
@@ -647,32 +433,81 @@ public class MediaQueryCacheUnitTests : BaseUnitTest<MediaQueryCache>
             .Where(x => x.Type == PlexMediaType.Movie)
             .Select(x => x.Id)
             .FirstAsync(CancellationToken);
-        var freshIds = new List<int> { 50, 51, 52, 53, 54 };
+        var allMovieIds = await IDbContext.PlexMovies
+            .OrderBy(x => x.SearchTitle)
+            .Select(x => x.Id)
+            .ToListAsync(CancellationToken);
 
-        var filter = CreateFilter(plexLibraryId: libraryId, sort: "year:asc", page: 1, pageSize: 5);
-        var buildResults = new Queue<Result<PagedMediaQueryResult>>([
-            Result.Ok(CreateResult([1, 2, 3, 4, 5])),
-            Result.Ok(CreateResult(freshIds)),
-        ]);
+        Mock.Mock<IGeneralSettings>().Setup(x => x.HideMediaFromOfflineServers).Returns(false);
+        Mock.Mock<IGeneralSettings>().Setup(x => x.HideMediaFromOwnedServers).Returns(false);
 
-        var commandExecutor = Mock.Mock<ICommandExecutor>();
-        commandExecutor
+        Mock.Mock<ICommandExecutor>()
             .Setup(x => x.Send(It.IsAny<GetMediaByTypeCommand>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(() => buildResults.Dequeue())
-            .Verifiable(Times.Exactly(2));
+            .Returns<GetMediaByTypeCommand, CancellationToken>((command, _) =>
+                Task.FromResult(Result.Ok(CreateResult(allMovieIds, command.Filter.MediaType))));
 
-        // Act — first call builds the snapshot
+        await Sut.BuildCache();
+        Mock.Mock<ICommandExecutor>().Reset();
+
+        var filter = CreateFilter(sort: "sortIndex:asc", page: 1, pageSize: 5);
+
+        // Verify warm cache hit
         var firstResult = await Sut.GetMediaAsync(filter, CancellationToken);
-        firstResult.Value.Items.Select(x => x.Id).ShouldBe([1, 2, 3, 4, 5]);
+        firstResult.IsSuccess.ShouldBeTrue();
+        firstResult.Value.Items.ShouldNotBeEmpty();
 
-        // Invalidate and verify second call builds fresh
+        // Act — invalidate library (marks dirty, queues background rebuild)
         Sut.InvalidateLibraries([libraryId], "test invalidation");
+
+        // Second call should still return stale cached data (not 503, not empty)
         var secondResult = await Sut.GetMediaAsync(filter, CancellationToken);
 
         // Assert
         secondResult.IsSuccess.ShouldBeTrue();
-        secondResult.Value.Items.Select(x => x.Id).ShouldBe(freshIds);
-        commandExecutor.Verify();
+        secondResult.Value.Items.Count.ShouldBeGreaterThan(0);
+    }
+
+    [Test]
+    public async Task ShouldNotEmptyState_WhenInvalidationHitsAndSubsequentRequestUsesStaleSnapshot()
+    {
+        // Arrange
+        await SetupDatabase(70323, cfg =>
+        {
+            cfg.PlexServerCount = 1;
+            cfg.PlexMovieLibraryCount = 1;
+            cfg.MovieCount = 15;
+        });
+
+        var libraryId = await IDbContext.PlexLibraries
+            .Where(x => x.Type == PlexMediaType.Movie)
+            .Select(x => x.Id)
+            .FirstAsync(CancellationToken);
+        var allMovieIds = await IDbContext.PlexMovies
+            .OrderBy(x => x.SearchTitle)
+            .Select(x => x.Id)
+            .ToListAsync(CancellationToken);
+
+        Mock.Mock<IGeneralSettings>().Setup(x => x.HideMediaFromOfflineServers).Returns(false);
+        Mock.Mock<IGeneralSettings>().Setup(x => x.HideMediaFromOwnedServers).Returns(false);
+
+        Mock.Mock<ICommandExecutor>()
+            .Setup(x => x.Send(It.IsAny<GetMediaByTypeCommand>(), It.IsAny<CancellationToken>()))
+            .Returns<GetMediaByTypeCommand, CancellationToken>((command, _) =>
+                Task.FromResult(Result.Ok(CreateResult(allMovieIds, command.Filter.MediaType))));
+
+        await Sut.BuildCache();
+        Mock.Mock<ICommandExecutor>().Reset();
+
+        var filter = CreateFilter(sort: "sortIndex:asc", page: 1, pageSize: 10);
+
+        // Act — invalidate first (simulates library refresh), then request
+        Sut.InvalidateLibraries([libraryId], "simulated library refresh");
+        var result = await Sut.GetMediaAsync(filter, CancellationToken);
+
+        // Assert — stale data available, not empty
+        result.IsSuccess.ShouldBeTrue();
+        result.Value.Items.ShouldNotBeEmpty();
+        result.Value.Items.Count.ShouldBe(10);
     }
 
     [Test]
@@ -691,75 +526,39 @@ public class MediaQueryCacheUnitTests : BaseUnitTest<MediaQueryCache>
             .Select(x => x.Id)
             .OrderBy(x => x)
             .ToListAsync(CancellationToken);
-        var unrelatedId = libraryIds[0] + libraryIds[1] + 999; // non-existent library
+        var unrelatedId = libraryIds[0] + libraryIds[1] + 999;
+        var allMovieIds = await IDbContext.PlexMovies
+            .OrderBy(x => x.SearchTitle)
+            .Select(x => x.Id)
+            .ToListAsync(CancellationToken);
 
-        var filter = CreateFilter(sort: "year:asc", page: 1, pageSize: 5);
+        Mock.Mock<IGeneralSettings>().Setup(x => x.HideMediaFromOfflineServers).Returns(false);
+        Mock.Mock<IGeneralSettings>().Setup(x => x.HideMediaFromOwnedServers).Returns(false);
 
-        var commandExecutor = Mock.Mock<ICommandExecutor>();
-        commandExecutor
+        Mock.Mock<ICommandExecutor>()
             .Setup(x => x.Send(It.IsAny<GetMediaByTypeCommand>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Result.Ok(CreateResult([10, 20, 30, 40, 50])))
-            .Verifiable(Times.Once());
+            .Returns<GetMediaByTypeCommand, CancellationToken>((command, _) =>
+                Task.FromResult(Result.Ok(CreateResult(allMovieIds, command.Filter.MediaType))));
+
+        await Sut.BuildCache();
+        Mock.Mock<ICommandExecutor>().Reset();
+
+        var filter = CreateFilter(sort: "sortIndex:asc", page: 1, pageSize: 5);
 
         // Act
         var firstResult = await Sut.GetMediaAsync(filter, CancellationToken);
         Sut.InvalidateLibraries([unrelatedId], "unrelated invalidation");
         var secondResult = await Sut.GetMediaAsync(filter, CancellationToken);
 
-        // Assert — should reuse cached snapshot (only one build total)
+        // Assert
         firstResult.IsSuccess.ShouldBeTrue();
         secondResult.IsSuccess.ShouldBeTrue();
-        secondResult.Value.Items.Select(x => x.Id).ShouldBe([10, 20, 30, 40, 50]);
-        commandExecutor.Verify();
+        secondResult.Value.Items.Select(x => x.Id).ShouldBe(firstResult.Value.Items.Select(x => x.Id));
     }
 
-    [Test]
-    public async Task ShouldDiscardInFlightBuild_WhenInvalidationOccursDuringBuild()
-    {
-        // Arrange
-        await SetupDatabase(70319, cfg =>
-        {
-            cfg.PlexServerCount = 1;
-            cfg.PlexMovieLibraryCount = 1;
-            cfg.MovieCount = 5;
-        });
-
-        var libraryId = await IDbContext.PlexLibraries
-            .Where(x => x.Type == PlexMediaType.Movie)
-            .Select(x => x.Id)
-            .FirstAsync(CancellationToken);
-
-        // Build that will be invalidated mid-flight
-        var staleBuild = new TaskCompletionSource<Result<PagedMediaQueryResult>>(TaskCreationOptions.RunContinuationsAsynchronously);
-        // Build after invalidation
-        var freshBuild = new TaskCompletionSource<Result<PagedMediaQueryResult>>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var buildQueue = new Queue<TaskCompletionSource<Result<PagedMediaQueryResult>>>([staleBuild, freshBuild]);
-
-        var filter = CreateFilter(plexLibraryId: libraryId, sort: "sortIndex:asc", page: 1, pageSize: 5);
-
-        var commandExecutor = Mock.Mock<ICommandExecutor>();
-        commandExecutor
-            .Setup(x => x.Send(It.IsAny<GetMediaByTypeCommand>(), It.IsAny<CancellationToken>()))
-            .Returns(() => buildQueue.Dequeue().Task)
-            .Verifiable(Times.Exactly(2));
-
-        // Act — start a build, invalidate, then complete the stale build
-        var firstRequest = Sut.GetMediaAsync(filter, CancellationToken);
-        Sut.InvalidateLibraries([libraryId], "mid-build invalidation");
-        staleBuild.SetResult(Result.Ok(CreateResult([100, 101, 102, 103, 104])));
-        var staleResult = await firstRequest;
-
-        // The stale build was discarded; next request triggers a fresh one
-        freshBuild.SetResult(Result.Ok(CreateResult([200, 201, 202, 203, 204])));
-        var freshResult = await Sut.GetMediaAsync(filter, CancellationToken);
-
-        // Assert
-        staleResult.IsFailed.ShouldBeTrue();
-        staleResult.Errors.ShouldContain(x => x.Message.Contains("invalidated"));
-        freshResult.IsSuccess.ShouldBeTrue();
-        freshResult.Value.Items.Select(x => x.Id).ShouldBe([200, 201, 202, 203, 204]);
-        commandExecutor.Verify();
-    }
+    // ──────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────
 
     private static MediaQueryFilter CreateFilter(
         PlexMediaType mediaType = PlexMediaType.Movie,
@@ -826,78 +625,4 @@ public class MediaQueryCacheUnitTests : BaseUnitTest<MediaQueryCache>
         HasThumb = false,
         Qualities = new List<PlexMediaQualityDTO>(),
     };
-
-    [Test]
-    public async Task ShouldReturnEmptyFilterArrays_InPageResponse()
-    {
-        // Arrange
-        await SetupDatabase(70320, cfg =>
-        {
-            cfg.PlexServerCount = 1;
-            cfg.PlexMovieLibraryCount = 1;
-            cfg.MovieCount = 10;
-        });
-
-        var filter = CreateFilter(sort: "sortIndex:asc", page: 1, pageSize: 5);
-
-        Mock.Mock<ICommandExecutor>()
-            .Setup(x => x.Send(It.IsAny<GetMediaByTypeCommand>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Result.Ok(CreateResult([1, 2, 3, 4, 5])))
-            .Verifiable(Times.Once());
-
-        // Act
-        var result = await Sut.GetMediaAsync(filter, CancellationToken);
-
-        // Assert
-        result.IsSuccess.ShouldBeTrue();
-        result.Value.Roles.ShouldBeEmpty();
-        result.Value.Countries.ShouldBeEmpty();
-        result.Value.Genres.ShouldBeEmpty();
-        result.Value.Qualities.ShouldBeEmpty();
-        Mock.Mock<ICommandExecutor>().Verify();
-    }
-
-    [Test]
-    public async Task ShouldSkipMetadataStorage_WhenBuildInvalidatedMidFlight()
-    {
-        // Arrange
-        await SetupDatabase(70321, cfg =>
-        {
-            cfg.PlexServerCount = 1;
-            cfg.PlexMovieLibraryCount = 1;
-            cfg.MovieCount = 5;
-        });
-
-        var libraryId = await IDbContext.PlexLibraries
-            .Where(x => x.Type == PlexMediaType.Movie)
-            .Select(x => x.Id)
-            .FirstAsync(CancellationToken);
-
-        var staleBuildTcs = new TaskCompletionSource<Result<PagedMediaQueryResult>>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var freshBuildTcs = new TaskCompletionSource<Result<PagedMediaQueryResult>>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var buildQueue = new Queue<TaskCompletionSource<Result<PagedMediaQueryResult>>>([staleBuildTcs, freshBuildTcs]);
-
-        var filter = CreateFilter(plexLibraryId: libraryId, sort: "year:asc", page: 1, pageSize: 5);
-
-        Mock.Mock<ICommandExecutor>()
-            .Setup(x => x.Send(It.IsAny<GetMediaByTypeCommand>(), It.IsAny<CancellationToken>()))
-            .Returns(() => buildQueue.Dequeue().Task)
-            .Verifiable(Times.Exactly(2));
-
-        // Act — start build, invalidate mid-flight, complete stale build, then verify fresh build succeeds
-        var firstRequest = Sut.GetMediaAsync(filter, CancellationToken);
-        Sut.InvalidateLibraries([libraryId], "mid-build invalidation");
-        staleBuildTcs.SetResult(Result.Ok(CreateResult([100, 200, 300, 400, 500])));
-        var staleResult = await firstRequest;
-
-        freshBuildTcs.SetResult(Result.Ok(CreateResult([10, 20, 30, 40, 50])));
-        var freshResult = await Sut.GetMediaAsync(filter, CancellationToken);
-
-        // Assert
-        staleResult.IsFailed.ShouldBeTrue();
-        staleResult.Errors.ShouldContain(x => x.Message.Contains("invalidated"));
-        freshResult.IsSuccess.ShouldBeTrue();
-        freshResult.Value.Items.Select(x => x.Id).ShouldBe([10, 20, 30, 40, 50]);
-        Mock.Mock<ICommandExecutor>().Verify();
-    }
 }


### PR DESCRIPTION
Fixes: https://github.com/Reaparr/Reaparr/issues/609

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Media query cache now warms in the background on cache misses, returning a clearer 503 (Service Unavailable) response while refresh occurs.
  - Added temporary suppression of cache invalidation during library sync “storms” to prevent invalidation loops.
- **Bug Fixes**
  - Storage-related download failures are now reported with a dedicated storage error status, and 503 outcomes correctly map to HTTP 503 responses.
  - Batch media retrieval now stops and returns the failure immediately on metadata lookup errors.
  - Improved available-disk-space detection on Windows.
- **Tests**
  - Updated and expanded unit tests for cache warmup, 503 behavior, and sync-storm invalidation suppression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->