### PR TITLE
fix(WebAPI): Apply SQLite WAL and busy_timeout PRAGMAs to Quartz ADO.…

### DIFF
--- a/src/AppHost/AppHost.csproj
+++ b/src/AppHost/AppHost.csproj
@@ -29,8 +29,8 @@
         <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.9" />
         <PackageReference Include="Photino.NET" Version="4.0.16" />
         <PackageReference Include="Velopack" Version="0.0.1298" />
-        <PackageReference Include="Quartz" Version="3.17.0" />
-        <PackageReference Include="Quartz.Extensions.Hosting" Version="3.17.0" />
+        <PackageReference Include="Quartz" Version="3.18.2" />
+        <PackageReference Include="Quartz.Extensions.Hosting" Version="3.18.2" />
         <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
         <PackageReference Include="Serilog.Sinks.AspNetCore.App.SignalR" Version="1.2.2" />
     </ItemGroup>

--- a/src/AppHost/ClientApp/cypress/e2e/pages/dialogs/check-server-connections-dialog.cy.ts
+++ b/src/AppHost/ClientApp/cypress/e2e/pages/dialogs/check-server-connections-dialog.cy.ts
@@ -109,6 +109,10 @@ describe('Check server connections dialog', () => {
 			cy.getCy(`check-server-connections-dialog-result-text-success-${successServer.id}`).should('exist');
 			cy.getCy(`check-server-connections-dialog-result-text-completed-${failedServer.id}`).should('exist');
 			cy.getCy(`check-server-connections-dialog-result-text-completed-${loadingServer.id}`).should('not.exist');
+			cy.getCy('check-server-connection-dialog-progress')
+				.should('have.attr', 'data-completed')
+				.and('equal', 'false');
+			cy.contains('Checking 2 of 3 Plex servers connections').should('be.visible');
 			cy.getCy(`check-server-connections-dialog-connection-title-${loadingInProgressConnection.id}`)
 				.closest('.q-tree__node')
 				.find(`[data-cy="check-server-connections-dialog-${loadingInProgressConnection.id}"]`)

--- a/src/AppHost/ClientApp/cypress/e2e/pages/settings/accounts/account-create.cy.ts
+++ b/src/AppHost/ClientApp/cypress/e2e/pages/settings/accounts/account-create.cy.ts
@@ -22,7 +22,7 @@ describe('Add Plex account to Reaparr', () => {
 		});
 	});
 
-	it('Should request a verification code when 2Fa is enabled for an Plex account', function () {
+	it('Should request a verification code, show invalid code error, and allow retry when 2FA is enabled', function () {
 		const plexAccount: PlexAccountDTO = generatePlexAccount({
 			id: 99,
 			partialData: {
@@ -42,29 +42,67 @@ describe('Add Plex account to Reaparr', () => {
 		// Validate button should be enabled
 		cy.getCy('account-dialog-validate-button').should('not.be.disabled');
 
-		// Validate Action, should return is2Fa true and isValidated false
+		// Initial Plex response: credentials are valid but require a 2FA code
 		cy.validatePlexCredentialsEndpoint({
+			isUnAuthorized: true,
 			partialData: {
+				clientId: plexAccount.clientId,
 				is2Fa: true,
 				isValidated: false,
 			},
-		});
+		}).as('validateNeeds2Fa');
 
 		cy.getCy('account-dialog-validate-button').click();
+		cy.wait('@validateNeeds2Fa');
 
 		// Verify 2FA dialog appears
 		cy.getCy('2fa-code-verification-dialog').should('be.visible');
+		cy.getCy('2fa-code-verification-error').should('not.exist');
 
-		// Insert verification code, should return is2Fa true and isValidated true
+		// Invalid verification code: backend returns unauthorized and keeps account unvalidated
+		cy.validatePlexCredentialsEndpoint({
+			isUnAuthorized: true,
+			partialData: {
+				clientId: plexAccount.clientId,
+				is2Fa: false,
+				isValidated: false,
+			},
+		}).as('validateInvalidCode');
+
+		cy.get(':nth-child(1) > [data-test="single-input"]').type('111111');
+		cy.wait('@validateInvalidCode').then((interception) => {
+			expect(interception.request.body.verificationCode).to.equal('111111');
+		});
+		cy.getCy('2fa-code-verification-dialog').should('be.visible');
+		cy.getCy('2fa-code-verification-error').should('be.visible');
+		cy.getCy('2fa-code-verification-dialog')
+			.find('[data-test="single-input"]')
+			.should(($inputs) => {
+				expect(Array.from($inputs, (input) => (input as HTMLInputElement).value)).to.deep.equal([
+					'',
+					'',
+					'',
+					'',
+					'',
+					'',
+				]);
+			});
+		cy.getCy('2fa-code-verification-confirm-button').should('be.disabled');
+		cy.getCy('account-dialog-save-button').should('be.disabled');
+
+		// Retry with a valid verification code
 		cy.validatePlexCredentialsEndpoint({
 			partialData: {
+				clientId: plexAccount.clientId,
 				is2Fa: true,
 				isValidated: true,
 			},
-		});
+		}).as('validateValidCode');
 
-		// Enter 2FA code
 		cy.get(':nth-child(1) > [data-test="single-input"]').type('123456');
+		cy.wait('@validateValidCode').then((interception) => {
+			expect(interception.request.body.verificationCode).to.equal('123456');
+		});
 
 		// Verify 2FA dialog closes after successful validation
 		cy.getCy('2fa-code-verification-dialog').should('not.exist');
@@ -325,6 +363,7 @@ describe('Add Plex account to Reaparr', () => {
 
 			// First validation attempt - should fail
 			cy.validatePlexCredentialsEndpoint({
+				isUnAuthorized: true,
 				partialData: {
 					isValidated: false,
 					is2Fa: false,

--- a/src/AppHost/ClientApp/src/components/Dialogs/AccountDialog/AccountTokenValidateDialog.vue
+++ b/src/AppHost/ClientApp/src/components/Dialogs/AccountDialog/AccountTokenValidateDialog.vue
@@ -48,15 +48,15 @@
 				</q-markup-table>
 
 				<QAlert
-				v-else
-				cy="auth-token-validation-dialog-invalid-token-alert"
-				type="error">
-				{{
-					accountDialogStore.isAuthTokenMode
-						? $t('components.account-token-validate-dialog.invalid-token')
-						: $t('components.account-token-validate-dialog.invalid-credentials')
-				}}
-			</QAlert>
+					v-else
+					cy="auth-token-validation-dialog-invalid-token-alert"
+					type="error">
+					{{
+						accountDialogStore.isAuthTokenMode
+							? $t('components.account-token-validate-dialog.invalid-token')
+							: $t('components.account-token-validate-dialog.invalid-credentials')
+					}}
+				</QAlert>
 			</div>
 		</template>
 		<template #actions="{ close }">

--- a/src/AppHost/ClientApp/src/components/Dialogs/AccountDialog/AccountTokenValidateDialog.vue
+++ b/src/AppHost/ClientApp/src/components/Dialogs/AccountDialog/AccountTokenValidateDialog.vue
@@ -48,11 +48,15 @@
 				</q-markup-table>
 
 				<QAlert
-					v-else
-					cy="auth-token-validation-dialog-invalid-token-alert"
-					type="error">
-					{{ $t('components.account-token-validate-dialog.invalid-token') }}
-				</QAlert>
+				v-else
+				cy="auth-token-validation-dialog-invalid-token-alert"
+				type="error">
+				{{
+					accountDialogStore.isAuthTokenMode
+						? $t('components.account-token-validate-dialog.invalid-token')
+						: $t('components.account-token-validate-dialog.invalid-credentials')
+				}}
+			</QAlert>
 			</div>
 		</template>
 		<template #actions="{ close }">

--- a/src/AppHost/ClientApp/src/components/Dialogs/AccountDialog/AccountVerificationCodeDialog.vue
+++ b/src/AppHost/ClientApp/src/components/Dialogs/AccountDialog/AccountVerificationCodeDialog.vue
@@ -33,6 +33,7 @@
 				</QRow>
 				<QRow
 					v-if="errors.length > 0"
+					data-cy="2fa-code-verification-error"
 					justify="center">
 					<QCol cols="auto">
 						<span style="color: red; font-weight: bold">
@@ -53,6 +54,7 @@
 				<!--	Confirm	-->
 				<QCol cols="auto">
 					<ConfirmButton
+						cy="2fa-code-verification-confirm-button"
 						:loading="loading"
 						:disabled="accountDialogStore.verificationCode.length < 6"
 						@click="onComplete" />
@@ -78,6 +80,7 @@ const loading = ref(false);
 const errors = ref<ErrorDTO[]>([]);
 
 function onComplete() {
+	set(errors, []);
 	set(loading, true);
 	useSubscription(
 		accountDialogStore.validateVerificationCode().subscribe({
@@ -86,6 +89,13 @@ function onComplete() {
 			},
 			complete: () => {
 				set(loading, false);
+				if (accountDialogStore.hasValidationErrors) {
+					set(errors, [
+						{
+							message: t('components.account-verification-code-dialog.error'),
+						} as ErrorDTO,
+					]);
+				}
 			},
 		}),
 	);

--- a/src/AppHost/ClientApp/src/components/Dialogs/AccountDialog/AccountVerificationCodeDialog.vue
+++ b/src/AppHost/ClientApp/src/components/Dialogs/AccountDialog/AccountVerificationCodeDialog.vue
@@ -16,6 +16,7 @@
 				<QRow justify="center">
 					<QCol cols="auto">
 						<VOtpInput
+							ref="otpInput"
 							id="verification-code"
 							v-model:value="accountDialogStore.verificationCode"
 							input-classes="otp-input"
@@ -66,7 +67,7 @@
 
 <script setup lang="ts">
 import VOtpInput from 'vue3-otp-input';
-import { set } from '@vueuse/core';
+import { get, set } from '@vueuse/core';
 import { useSubscription } from '@vueuse/rxjs';
 import { DialogType } from '@enums';
 import { useAccountDialogStore, useI18n } from '#imports';
@@ -75,6 +76,8 @@ import type { ErrorDTO } from '@dto';
 const { t } = useI18n();
 
 const accountDialogStore = useAccountDialogStore();
+
+const otpInput = ref<InstanceType<typeof VOtpInput>>();
 
 const loading = ref(false);
 const errors = ref<ErrorDTO[]>([]);
@@ -95,6 +98,7 @@ function onComplete() {
 							message: t('components.account-verification-code-dialog.error'),
 						} as ErrorDTO,
 					]);
+					get(otpInput)?.clearInput();
 				}
 			},
 		}),

--- a/src/AppHost/ClientApp/src/components/Dialogs/CheckServerConnectionsDialog.vue
+++ b/src/AppHost/ClientApp/src/components/Dialogs/CheckServerConnectionsDialog.vue
@@ -218,15 +218,16 @@ const plexServerNodes = computed((): IPlexServerNode[] => {
 		const hasSuccessfulConnection = hasConnections
 			? mappedConnections.some((connection) => connection.connectionSuccessful)
 			: false;
+		const serverCompleted = serverHasProgress
+			? (hasConnections ? hasSuccessfulConnection || !hasInProgressConnections : true)
+			: false;
 
 		return {
 			id: server.id,
 			index: uniqueIndex++,
 			type: 'server',
 			title: serverStore.getServerName(server.id),
-			completed: serverHasProgress
-				? (hasConnections ? !hasInProgressConnections : true)
-				: false,
+			completed: serverCompleted,
 			connectionSuccessful: hasSuccessfulConnection,
 			hasInProgressConnections,
 			noConnections: !hasConnections,

--- a/src/AppHost/ClientApp/src/lang/de-DE.json
+++ b/src/AppHost/ClientApp/src/lang/de-DE.json
@@ -231,6 +231,7 @@
                 "username": "Nutzername"
             },
             "invalid-token": "Die Zugangsdaten oder das Token waren ungültig und/oder sind abgelaufen.",
+            "invalid-credentials": "Benutzername oder Passwort sind ungültig. Bitte überprüfen Sie Ihre Zugangsdaten und versuchen Sie es erneut.",
             "sub-header": "Das Token: {authToken} gehört zum Plex-Konto:",
             "title": "Validierung des Plex.tv-Authentifizierungstokens"
         },

--- a/src/AppHost/ClientApp/src/lang/en-US.json
+++ b/src/AppHost/ClientApp/src/lang/en-US.json
@@ -231,6 +231,7 @@
                 "username": "Username"
             },
             "invalid-token": "The credentials or token were invalid and/or have expired.",
+            "invalid-credentials": "The username or password was invalid. Please double-check your credentials and try again.",
             "sub-header": "The token: {authToken} belongs to the Plex account:",
             "title": "Plex.tv Authentication Token Validation"
         },

--- a/src/AppHost/ClientApp/src/lang/fr-FR.json
+++ b/src/AppHost/ClientApp/src/lang/fr-FR.json
@@ -231,6 +231,7 @@
                 "username": "Nom d'utilisateur"
             },
             "invalid-token": "Les identifiants ou le jeton n'étaient pas valides et/ou ont expiré.",
+            "invalid-credentials": "Le nom d'utilisateur ou le mot de passe est incorrect. Veuillez vérifier vos identifiants et réessayer.",
             "sub-header": "Le jeton : {authToken} appartient au compte Plex :",
             "title": "Validation du jeton d'authentification Plex.tv"
         },

--- a/src/AppHost/ClientApp/src/lang/pl-PL.json
+++ b/src/AppHost/ClientApp/src/lang/pl-PL.json
@@ -231,6 +231,7 @@
                 "username": "Nazwa użytkownika"
             },
             "invalid-token": "Dane logowania lub token były nieprawidłowe i/lub wygasły.",
+            "invalid-credentials": "Nazwa użytkownika lub hasło są nieprawidłowe. Sprawdź dane logowania i spróbuj ponownie.",
             "sub-header": "Token: {authToken} należy do konta Plex:",
             "title": "Walidacja tokena uwierzytelniającego Plex.tv"
         },

--- a/src/AppHost/ClientApp/src/store/accountDialogStore.ts
+++ b/src/AppHost/ClientApp/src/store/accountDialogStore.ts
@@ -171,6 +171,7 @@ export const useAccountDialogStore = defineStore(StoreNames.AccountDialogStore, 
 						// If 2FA is required, open the verification code dialog instead
 						if (value?.is2Fa) {
 							state.clientId = value.clientId;
+							state.hasValidationErrors = false;
 							Log.info('Account has 2FA enabled');
 							dialogStore.openDialog(DialogType.AccountVerificationCodeDialog);
 							return;
@@ -226,6 +227,7 @@ export const useAccountDialogStore = defineStore(StoreNames.AccountDialogStore, 
 					if (isSuccess && value) {
 						if (value.isUnAuthorized) {
 							Log.error('Invalid verification code, 2FA still required');
+							state.hasValidationErrors = true;
 							state.verificationCode = '';
 							return;
 						}

--- a/src/AppHost/ClientApp/src/store/accountDialogStore.ts
+++ b/src/AppHost/ClientApp/src/store/accountDialogStore.ts
@@ -167,6 +167,15 @@ export const useAccountDialogStore = defineStore(StoreNames.AccountDialogStore, 
 					if (!isSuccess || !value || value.isUnAuthorized) {
 						state.isValidated = false;
 						state.hasValidationErrors = true;
+
+						// If 2FA is required, open the verification code dialog instead
+						if (value?.is2Fa) {
+							state.clientId = value.clientId;
+							Log.info('Account has 2FA enabled');
+							dialogStore.openDialog(DialogType.AccountVerificationCodeDialog);
+							return;
+						}
+
 						dialogStore.openDialog(DialogType.AccountTokenValidateDialog);
 						return;
 					}
@@ -206,6 +215,7 @@ export const useAccountDialogStore = defineStore(StoreNames.AccountDialogStore, 
 					state.isValidated = false;
 					state.hasValidationErrors = true;
 					Log.error('Credentials validation failed', error);
+					dialogStore.openDialog(DialogType.AccountTokenValidateDialog);
 					return of({ value: null, isSuccess: false });
 				}),
 			);
@@ -214,12 +224,19 @@ export const useAccountDialogStore = defineStore(StoreNames.AccountDialogStore, 
 			return plexAccountApi.validatePlexCredentialsEndpoint(get(getters.getAccountData)).pipe(
 				tap(({ value, isSuccess }) => {
 					if (isSuccess && value) {
+						if (value.isUnAuthorized) {
+							Log.error('Invalid verification code, 2FA still required');
+							state.verificationCode = '';
+							return;
+						}
 						dialogStore.closeDialog(DialogType.AccountVerificationCodeDialog);
 						// Update state with validated credentials data
 						updateStateWithAccountData(value);
+						state.hasValidationErrors = false;
 					} else {
 						Log.error('Validate Error', value);
 					}
+					state.verificationCode = '';
 				}),
 			);
 		},

--- a/src/AppHost/ClientApp/tests/nuxt/stores/account-dialog-store/validate-plex-account.test.ts
+++ b/src/AppHost/ClientApp/tests/nuxt/stores/account-dialog-store/validate-plex-account.test.ts
@@ -176,7 +176,7 @@ describe('AccountDialogStore.validatePlexAccount()', () => {
 
 		// Assert
 		expect(accountDialogStore.isValidated).toEqual(false);
-		expect(accountDialogStore.hasValidationErrors).toEqual(true);
+		expect(accountDialogStore.hasValidationErrors).toEqual(false);
 		expect(accountDialogStore.validateLoading).toEqual(false);
 		expect(accountDialogStore.clientId).toEqual('server-assigned-client-id');
 		expect(openDialogSpy).toHaveBeenCalledWith('account-verification-code-dialog');

--- a/src/AppHost/ClientApp/tests/nuxt/stores/account-dialog-store/validate-plex-account.test.ts
+++ b/src/AppHost/ClientApp/tests/nuxt/stores/account-dialog-store/validate-plex-account.test.ts
@@ -2,7 +2,7 @@ import { describe, beforeAll, beforeEach, test, expect, vi } from 'vitest';
 import { createPinia, setActivePinia } from 'pinia';
 import { baseSetup, baseVars, getAxiosMock, subscribeSpyTo } from '@services-test-base';
 import { PlexAccountPaths } from '@api-urls';
-import { generateResultDTO } from '@mock';
+import { generateFailedResultDTO, generateResultDTO } from '@mock';
 import { useAccountDialogStore, useDialogStore } from '@store';
 
 describe('AccountDialogStore.validatePlexAccount()', () => {
@@ -202,5 +202,94 @@ describe('AccountDialogStore.validatePlexAccount()', () => {
 		expect(accountDialogStore.hasValidationErrors).toEqual(true);
 		expect(accountDialogStore.validateLoading).toEqual(false);
 		expect(openDialogSpy).toHaveBeenCalledWith('account-token-validate-dialog');
+	});
+
+	test('Should open token validate dialog when API returns unsuccessful result (isSuccess=false)', async () => {
+		// Arrange
+		const dialogStore = useDialogStore();
+		const openDialogSpy = vi.spyOn(dialogStore, 'openDialog');
+		const accountDialogStore = useAccountDialogStore();
+		accountDialogStore.username = 'user';
+		accountDialogStore.password = 'pass';
+
+		mock.onPost(PlexAccountPaths.validatePlexCredentialsEndpoint()).reply(200, generateFailedResultDTO());
+
+		// Act
+		const result = subscribeSpyTo(accountDialogStore.validatePlexAccount());
+		await result.onComplete();
+
+		// Assert
+		expect(accountDialogStore.isValidated).toEqual(false);
+		expect(accountDialogStore.hasValidationErrors).toEqual(true);
+		expect(accountDialogStore.validateLoading).toEqual(false);
+		expect(openDialogSpy).toHaveBeenCalledWith('account-token-validate-dialog');
+	});
+
+	test('Should open token validate dialog when account has no 2FA and is not validated', async () => {
+		// Arrange
+		const dialogStore = useDialogStore();
+		const openDialogSpy = vi.spyOn(dialogStore, 'openDialog');
+		const accountDialogStore = useAccountDialogStore();
+		accountDialogStore.username = 'user';
+		accountDialogStore.password = 'pass';
+
+		mock.onPost(PlexAccountPaths.validatePlexCredentialsEndpoint()).reply(200, generateResultDTO({
+			is2Fa: false,
+			authenticationToken: '',
+			clientId: 'client-id',
+			email: '',
+			isUnAuthorized: false,
+			isValidated: false,
+			password: 'pass',
+			plexId: 0,
+			title: '',
+			username: 'user',
+			uuid: '',
+			validatedAt: null,
+		}));
+
+		// Act
+		const result = subscribeSpyTo(accountDialogStore.validatePlexAccount());
+		await result.onComplete();
+
+		// Assert
+		expect(accountDialogStore.isValidated).toEqual(false);
+		expect(accountDialogStore.hasValidationErrors).toEqual(true);
+		expect(accountDialogStore.validateLoading).toEqual(false);
+		expect(openDialogSpy).toHaveBeenCalledWith('account-token-validate-dialog');
+	});
+
+	test('Should log warning and not open any dialog when account is validated with 2FA (inconsistent state)', async () => {
+		// Arrange
+		const dialogStore = useDialogStore();
+		const openDialogSpy = vi.spyOn(dialogStore, 'openDialog');
+		const accountDialogStore = useAccountDialogStore();
+		accountDialogStore.username = 'user';
+		accountDialogStore.password = 'pass';
+
+		mock.onPost(PlexAccountPaths.validatePlexCredentialsEndpoint()).reply(200, generateResultDTO({
+			is2Fa: true,
+			authenticationToken: 'token',
+			clientId: 'client-id',
+			email: 'user@test.dev',
+			isUnAuthorized: false,
+			isValidated: true,
+			password: 'pass',
+			plexId: 42,
+			title: 'Title',
+			username: 'user',
+			uuid: 'uuid',
+			validatedAt: '2026-04-03T00:00:00Z',
+		}));
+
+		// Act
+		const result = subscribeSpyTo(accountDialogStore.validatePlexAccount());
+		await result.onComplete();
+
+		// Assert
+		expect(accountDialogStore.isValidated).toEqual(true);
+		expect(accountDialogStore.hasValidationErrors).toEqual(false);
+		expect(accountDialogStore.validateLoading).toEqual(false);
+		expect(openDialogSpy).not.toHaveBeenCalled();
 	});
 });

--- a/src/AppHost/ClientApp/tests/nuxt/stores/account-dialog-store/validate-plex-account.test.ts
+++ b/src/AppHost/ClientApp/tests/nuxt/stores/account-dialog-store/validate-plex-account.test.ts
@@ -146,4 +146,61 @@ describe('AccountDialogStore.validatePlexAccount()', () => {
 		expect(accountDialogStore.validateLoading).toEqual(false);
 		expect(openDialogSpy).not.toHaveBeenCalledWith('account-token-validate-dialog');
 	});
+
+	test('Should open verification code dialog and set clientId when Plex API returns 2FA unauthorized', async () => {
+		// Arrange
+		const dialogStore = useDialogStore();
+		const openDialogSpy = vi.spyOn(dialogStore, 'openDialog');
+		const accountDialogStore = useAccountDialogStore();
+		accountDialogStore.username = '2fa-user';
+		accountDialogStore.password = '2fa-pass';
+
+		mock.onPost(PlexAccountPaths.validatePlexCredentialsEndpoint()).reply(200, generateResultDTO({
+			is2Fa: true,
+			authenticationToken: '',
+			clientId: 'server-assigned-client-id',
+			email: '',
+			isUnAuthorized: true,
+			isValidated: false,
+			password: '2fa-pass',
+			plexId: 0,
+			title: '',
+			username: '2fa-user',
+			uuid: '',
+			validatedAt: null,
+		}));
+
+		// Act
+		const result = subscribeSpyTo(accountDialogStore.validatePlexAccount());
+		await result.onComplete();
+
+		// Assert
+		expect(accountDialogStore.isValidated).toEqual(false);
+		expect(accountDialogStore.hasValidationErrors).toEqual(true);
+		expect(accountDialogStore.validateLoading).toEqual(false);
+		expect(accountDialogStore.clientId).toEqual('server-assigned-client-id');
+		expect(openDialogSpy).toHaveBeenCalledWith('account-verification-code-dialog');
+		expect(openDialogSpy).not.toHaveBeenCalledWith('account-token-validate-dialog');
+	});
+
+	test('Should open token validate dialog and show validation errors on network error', async () => {
+		// Arrange
+		const dialogStore = useDialogStore();
+		const openDialogSpy = vi.spyOn(dialogStore, 'openDialog');
+		const accountDialogStore = useAccountDialogStore();
+		accountDialogStore.username = 'user';
+		accountDialogStore.password = 'pass';
+
+		mock.onPost(PlexAccountPaths.validatePlexCredentialsEndpoint()).reply(500);
+
+		// Act
+		const result = subscribeSpyTo(accountDialogStore.validatePlexAccount());
+		await result.onComplete();
+
+		// Assert
+		expect(accountDialogStore.isValidated).toEqual(false);
+		expect(accountDialogStore.hasValidationErrors).toEqual(true);
+		expect(accountDialogStore.validateLoading).toEqual(false);
+		expect(openDialogSpy).toHaveBeenCalledWith('account-token-validate-dialog');
+	});
 });

--- a/src/AppHost/ClientApp/tests/nuxt/stores/account-dialog-store/validate-plex-token.test.ts
+++ b/src/AppHost/ClientApp/tests/nuxt/stores/account-dialog-store/validate-plex-token.test.ts
@@ -1,0 +1,163 @@
+import { describe, beforeAll, beforeEach, test, expect, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { baseSetup, baseVars, getAxiosMock, subscribeSpyTo } from '@services-test-base';
+import { PlexAccountPaths } from '@api-urls';
+import { generateFailedResultDTO, generateResultDTO } from '@mock';
+import { useAccountDialogStore, useDialogStore } from '@store';
+
+describe('AccountDialogStore.validatePlexToken()', () => {
+	let { mock } = baseVars();
+
+	beforeAll(() => {
+		baseSetup();
+	});
+
+	beforeEach(() => {
+		mock = getAxiosMock();
+		setActivePinia(createPinia());
+	});
+
+	test('Should open token validate dialog and update state on successful token validation', async () => {
+		// Arrange
+		const dialogStore = useDialogStore();
+		const openDialogSpy = vi.spyOn(dialogStore, 'openDialog');
+		const accountDialogStore = useAccountDialogStore();
+		accountDialogStore.displayName = 'Test User';
+		accountDialogStore.customAuthenticationToken = 'valid-token';
+
+		mock.onPost(PlexAccountPaths.validatePlexTokenEndpoint()).reply(200, generateResultDTO({
+			is2Fa: false,
+			clientId: 'client-id',
+			customAuthenticationToken: 'valid-token',
+			email: 'user@test.dev',
+			isUnAuthorized: false,
+			isValidated: true,
+			plexId: 42,
+			title: 'User Title',
+			username: 'plex-user',
+			uuid: 'account-uuid',
+			validatedAt: '2026-04-03T00:00:00Z',
+		}));
+
+		// Act
+		const result = subscribeSpyTo(accountDialogStore.validatePlexToken());
+		await result.onComplete();
+
+		// Assert
+		expect(accountDialogStore.isValidated).toEqual(true);
+		expect(accountDialogStore.hasValidationErrors).toEqual(false);
+		expect(accountDialogStore.validateLoading).toEqual(false);
+		expect(accountDialogStore.plexId).toEqual(42);
+		expect(accountDialogStore.title).toEqual('User Title');
+		expect(accountDialogStore.email).toEqual('user@test.dev');
+		expect(openDialogSpy).toHaveBeenCalledWith('account-token-validate-dialog');
+	});
+
+	test('Should set displayName from email when token validates but displayName is empty', async () => {
+		// Arrange
+		const dialogStore = useDialogStore();
+		const openDialogSpy = vi.spyOn(dialogStore, 'openDialog');
+		const accountDialogStore = useAccountDialogStore();
+		accountDialogStore.displayName = '';
+		accountDialogStore.customAuthenticationToken = 'valid-token';
+
+		mock.onPost(PlexAccountPaths.validatePlexTokenEndpoint()).reply(200, generateResultDTO({
+			is2Fa: false,
+			clientId: 'client-id',
+			customAuthenticationToken: 'valid-token',
+			email: 'fallback@test.dev',
+			isUnAuthorized: false,
+			isValidated: true,
+			plexId: 7,
+			title: '',
+			username: 'plex-user',
+			uuid: 'uuid',
+			validatedAt: '2026-04-03T00:00:00Z',
+		}));
+
+		// Act
+		const result = subscribeSpyTo(accountDialogStore.validatePlexToken());
+		await result.onComplete();
+
+		// Assert
+		expect(accountDialogStore.isValidated).toEqual(true);
+		expect(accountDialogStore.hasValidationErrors).toEqual(false);
+		expect(accountDialogStore.displayName).toEqual('fallback@test.dev');
+		expect(openDialogSpy).toHaveBeenCalledWith('account-token-validate-dialog');
+	});
+
+	test('Should open token validate dialog and set error state when token is unauthorized', async () => {
+		// Arrange
+		const dialogStore = useDialogStore();
+		const openDialogSpy = vi.spyOn(dialogStore, 'openDialog');
+		const accountDialogStore = useAccountDialogStore();
+		accountDialogStore.displayName = 'Test User';
+		accountDialogStore.customAuthenticationToken = 'bad-token';
+
+		mock.onPost(PlexAccountPaths.validatePlexTokenEndpoint()).reply(200, generateResultDTO({
+			is2Fa: false,
+			clientId: '',
+			customAuthenticationToken: '',
+			email: '',
+			isUnAuthorized: true,
+			isValidated: false,
+			plexId: 0,
+			title: '',
+			username: '',
+			uuid: '',
+			validatedAt: null,
+		}));
+
+		// Act
+		const result = subscribeSpyTo(accountDialogStore.validatePlexToken());
+		await result.onComplete();
+
+		// Assert
+		expect(accountDialogStore.isValidated).toEqual(false);
+		expect(accountDialogStore.hasValidationErrors).toEqual(true);
+		expect(accountDialogStore.validateLoading).toEqual(false);
+		expect(openDialogSpy).toHaveBeenCalledWith('account-token-validate-dialog');
+	});
+
+	test('Should open token validate dialog when API returns unsuccessful result', async () => {
+		// Arrange
+		const dialogStore = useDialogStore();
+		const openDialogSpy = vi.spyOn(dialogStore, 'openDialog');
+		const accountDialogStore = useAccountDialogStore();
+		accountDialogStore.displayName = 'Test User';
+		accountDialogStore.customAuthenticationToken = 'token';
+
+		mock.onPost(PlexAccountPaths.validatePlexTokenEndpoint()).reply(200, generateFailedResultDTO());
+
+		// Act
+		const result = subscribeSpyTo(accountDialogStore.validatePlexToken());
+		await result.onComplete();
+
+		// Assert
+		expect(accountDialogStore.isValidated).toEqual(false);
+		expect(accountDialogStore.hasValidationErrors).toEqual(true);
+		expect(accountDialogStore.validateLoading).toEqual(false);
+		expect(openDialogSpy).toHaveBeenCalledWith('account-token-validate-dialog');
+	});
+
+	test('Should open token validate dialog and show validation errors on network error', async () => {
+		// Arrange
+		const dialogStore = useDialogStore();
+		const openDialogSpy = vi.spyOn(dialogStore, 'openDialog');
+		const accountDialogStore = useAccountDialogStore();
+		accountDialogStore.displayName = 'Test User';
+		accountDialogStore.customAuthenticationToken = 'token';
+
+		mock.onPost(PlexAccountPaths.validatePlexTokenEndpoint()).reply(500);
+
+		// Act
+		const result = subscribeSpyTo(accountDialogStore.validatePlexToken());
+		await result.onComplete();
+
+		// Assert
+		expect(accountDialogStore.isValidated).toEqual(false);
+		expect(accountDialogStore.hasValidationErrors).toEqual(true);
+		expect(accountDialogStore.validateLoading).toEqual(false);
+		expect(openDialogSpy).toHaveBeenCalledWith('account-token-validate-dialog');
+	});
+});

--- a/src/AppHost/ClientApp/tests/nuxt/stores/account-dialog-store/validate-verification-code.test.ts
+++ b/src/AppHost/ClientApp/tests/nuxt/stores/account-dialog-store/validate-verification-code.test.ts
@@ -1,0 +1,231 @@
+import { describe, beforeAll, beforeEach, test, expect, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { baseSetup, baseVars, getAxiosMock, subscribeSpyTo } from '@services-test-base';
+import { PlexAccountPaths } from '@api-urls';
+import { generateFailedResultDTO, generateResultDTO } from '@mock';
+import { useAccountDialogStore, useDialogStore } from '@store';
+
+describe('AccountDialogStore.validateVerificationCode()', () => {
+	let { mock } = baseVars();
+
+	beforeAll(() => {
+		baseSetup();
+	});
+
+	beforeEach(() => {
+		mock = getAxiosMock();
+		setActivePinia(createPinia());
+	});
+
+	test('Should close verification dialog, update state, and reset validation errors on success', async () => {
+		// Arrange
+		const dialogStore = useDialogStore();
+		const closeDialogSpy = vi.spyOn(dialogStore, 'closeDialog');
+		const accountDialogStore = useAccountDialogStore();
+		accountDialogStore.username = 'user';
+		accountDialogStore.password = 'pass';
+		accountDialogStore.clientId = 'client-id';
+		accountDialogStore.verificationCode = '123456';
+		accountDialogStore.hasValidationErrors = true;
+
+		mock.onPost(PlexAccountPaths.validatePlexCredentialsEndpoint()).reply(200, generateResultDTO({
+			is2Fa: true,
+			authenticationToken: 'valid-token',
+			clientId: 'client-id',
+			email: 'user@test.dev',
+			isUnAuthorized: false,
+			isValidated: true,
+			password: 'pass',
+			plexId: 99,
+			title: 'User Title',
+			username: 'user',
+			uuid: 'account-uuid',
+			validatedAt: '2026-04-03T00:00:00Z',
+		}));
+
+		// Act
+		const result = subscribeSpyTo(accountDialogStore.validateVerificationCode());
+		await result.onComplete();
+
+		// Assert
+		expect(accountDialogStore.isValidated).toEqual(true);
+		expect(accountDialogStore.hasValidationErrors).toEqual(false);
+		expect(accountDialogStore.validateLoading).toEqual(false);
+		expect(accountDialogStore.email).toEqual('user@test.dev');
+		expect(accountDialogStore.authenticationToken).toEqual('valid-token');
+		expect(closeDialogSpy).toHaveBeenCalledWith('account-verification-code-dialog');
+	});
+
+	test('Should keep verification dialog open and not update state when verification code is rejected', async () => {
+		// Arrange
+		const dialogStore = useDialogStore();
+		const closeDialogSpy = vi.spyOn(dialogStore, 'closeDialog');
+		const accountDialogStore = useAccountDialogStore();
+		accountDialogStore.username = 'user';
+		accountDialogStore.password = 'pass';
+		accountDialogStore.clientId = 'client-id';
+		accountDialogStore.verificationCode = 'wrong-code';
+		accountDialogStore.hasValidationErrors = true;
+		accountDialogStore.isValidated = false;
+
+		mock.onPost(PlexAccountPaths.validatePlexCredentialsEndpoint()).reply(200, generateResultDTO({
+			is2Fa: true,
+			authenticationToken: '',
+			clientId: 'client-id',
+			email: '',
+			isUnAuthorized: true,
+			isValidated: false,
+			password: 'pass',
+			plexId: 0,
+			title: '',
+			username: 'user',
+			uuid: '',
+			validatedAt: null,
+		}));
+
+		// Act
+		const result = subscribeSpyTo(accountDialogStore.validateVerificationCode());
+		await result.onComplete();
+
+		// Assert
+		expect(accountDialogStore.isValidated).toEqual(false);
+		expect(accountDialogStore.hasValidationErrors).toEqual(true);
+		expect(closeDialogSpy).not.toHaveBeenCalled();
+	});
+
+	test('Should keep verification dialog open and log error when API returns unsuccessful result', async () => {
+		// Arrange
+		const dialogStore = useDialogStore();
+		const closeDialogSpy = vi.spyOn(dialogStore, 'closeDialog');
+		const accountDialogStore = useAccountDialogStore();
+		accountDialogStore.username = 'user';
+		accountDialogStore.password = 'pass';
+		accountDialogStore.clientId = 'client-id';
+		accountDialogStore.verificationCode = '123456';
+		accountDialogStore.hasValidationErrors = true;
+		accountDialogStore.isValidated = false;
+
+		mock.onPost(PlexAccountPaths.validatePlexCredentialsEndpoint()).reply(200, generateFailedResultDTO());
+
+		// Act
+		const result = subscribeSpyTo(accountDialogStore.validateVerificationCode());
+		await result.onComplete();
+
+		// Assert
+		expect(accountDialogStore.isValidated).toEqual(false);
+		expect(accountDialogStore.hasValidationErrors).toEqual(true);
+		expect(closeDialogSpy).not.toHaveBeenCalled();
+	});
+
+	test('Should preserve account credentials in state after successful verification code submission', async () => {
+		// Arrange
+		const dialogStore = useDialogStore();
+		const closeDialogSpy = vi.spyOn(dialogStore, 'closeDialog');
+		const accountDialogStore = useAccountDialogStore();
+		accountDialogStore.username = 'preserved-user';
+		accountDialogStore.password = 'preserved-pass';
+		accountDialogStore.clientId = 'preserved-client-id';
+		accountDialogStore.verificationCode = '654321';
+		accountDialogStore.hasValidationErrors = true;
+
+		mock.onPost(PlexAccountPaths.validatePlexCredentialsEndpoint()).reply(200, generateResultDTO({
+			is2Fa: false,
+			authenticationToken: 'new-token',
+			clientId: 'preserved-client-id',
+			email: 'preserved@test.dev',
+			isUnAuthorized: false,
+			isValidated: true,
+			password: 'preserved-pass',
+			plexId: 77,
+			title: 'Preserved',
+			username: 'preserved-user',
+			uuid: 'preserved-uuid',
+			validatedAt: '2026-04-03T00:00:00Z',
+		}));
+
+		// Act
+		const result = subscribeSpyTo(accountDialogStore.validateVerificationCode());
+		await result.onComplete();
+
+		// Assert
+		expect(accountDialogStore.isValidated).toEqual(true);
+		expect(accountDialogStore.hasValidationErrors).toEqual(false);
+		expect(accountDialogStore.username).toEqual('preserved-user');
+		expect(accountDialogStore.password).toEqual('preserved-pass');
+		expect(accountDialogStore.plexId).toEqual(77);
+		expect(accountDialogStore.uuid).toEqual('preserved-uuid');
+		expect(accountDialogStore.title).toEqual('Preserved');
+		expect(closeDialogSpy).toHaveBeenCalledWith('account-verification-code-dialog');
+	});
+
+	test('Should clear verification code after successful submission', async () => {
+		// Arrange
+		const dialogStore = useDialogStore();
+		const closeDialogSpy = vi.spyOn(dialogStore, 'closeDialog');
+		const accountDialogStore = useAccountDialogStore();
+		accountDialogStore.username = 'user';
+		accountDialogStore.password = 'pass';
+		accountDialogStore.clientId = 'client-id';
+		accountDialogStore.verificationCode = '123456';
+		accountDialogStore.hasValidationErrors = true;
+
+		mock.onPost(PlexAccountPaths.validatePlexCredentialsEndpoint()).reply(200, generateResultDTO({
+			is2Fa: false,
+			authenticationToken: 'token',
+			clientId: 'client-id',
+			email: 'user@test.dev',
+			isUnAuthorized: false,
+			isValidated: true,
+			password: 'pass',
+			plexId: 1,
+			title: 'Title',
+			username: 'user',
+			uuid: 'uuid',
+			validatedAt: '2026-04-03T00:00:00Z',
+		}));
+
+		// Act
+		const result = subscribeSpyTo(accountDialogStore.validateVerificationCode());
+		await result.onComplete();
+
+		// Assert
+		expect(accountDialogStore.verificationCode).toEqual('');
+		expect(closeDialogSpy).toHaveBeenCalledWith('account-verification-code-dialog');
+	});
+
+	test('Should clear verification code after rejected submission', async () => {
+		// Arrange
+		const dialogStore = useDialogStore();
+		const closeDialogSpy = vi.spyOn(dialogStore, 'closeDialog');
+		const accountDialogStore = useAccountDialogStore();
+		accountDialogStore.username = 'user';
+		accountDialogStore.password = 'pass';
+		accountDialogStore.clientId = 'client-id';
+		accountDialogStore.verificationCode = 'wrong-code';
+		accountDialogStore.hasValidationErrors = true;
+
+		mock.onPost(PlexAccountPaths.validatePlexCredentialsEndpoint()).reply(200, generateResultDTO({
+			is2Fa: true,
+			authenticationToken: '',
+			clientId: 'client-id',
+			email: '',
+			isUnAuthorized: true,
+			isValidated: false,
+			password: 'pass',
+			plexId: 0,
+			title: '',
+			username: 'user',
+			uuid: '',
+			validatedAt: null,
+		}));
+
+		// Act
+		const result = subscribeSpyTo(accountDialogStore.validateVerificationCode());
+		await result.onComplete();
+
+		// Assert
+		expect(accountDialogStore.verificationCode).toEqual('');
+		expect(accountDialogStore.isValidated).toEqual(false);
+		expect(closeDialogSpy).not.toHaveBeenCalled();
+	});
+});

--- a/src/AppHost/packages.lock.json
+++ b/src/AppHost/packages.lock.json
@@ -73,17 +73,17 @@
       },
       "Quartz": {
         "type": "Direct",
-        "requested": "[3.17.0, )",
-        "resolved": "3.17.0",
-        "contentHash": "Ko3I49Yz1DqlxWi+fXqdG0FYJlHyGnra86m9RSlhPjIoXy7ip8FxyYJ70HcHc5s3xije0QvX81qG2dlxLEI7hQ=="
+        "requested": "[3.18.2, )",
+        "resolved": "3.18.2",
+        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA=="
       },
       "Quartz.Extensions.Hosting": {
         "type": "Direct",
-        "requested": "[3.17.0, )",
-        "resolved": "3.17.0",
-        "contentHash": "6XgnbMBMsn5a7u2amkZVWKljVCQnO45SxDznpaRonXWolLNeX6Fx5t/73zigVshGLs3Q1A+NSv5z6oPTgv37sA==",
+        "requested": "[3.18.2, )",
+        "resolved": "3.18.2",
+        "contentHash": "6uSMAm4FArjtVoxBjlkA+gHL1Eln2ngIOnRTrVrYxtSlM5PpLQd2aV+fc/OOwfwt+AyDm69HOAybEFqVvyyG2A==",
         "dependencies": {
-          "Quartz.Extensions.DependencyInjection": "3.17.0"
+          "Quartz.Extensions.DependencyInjection": "3.18.2"
         }
       },
       "Serilog.AspNetCore": {
@@ -641,18 +641,18 @@
       },
       "Quartz.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "SYPUS3eOwbYFv9mXwAqz6R0G5SHztRg0qG7GzQBsncSEW7y2vRvcMxnaYM5bGP1fF4SFBMdYAj25gGgQvD+tOA==",
+        "resolved": "3.18.2",
+        "contentHash": "+P0z/WUQZF/QrY5wB1wgvl9/VkiWqGR/K5bdtjW1qiFBraEoe/dqfNTxXQPnSZHnha1qmSBRoa5oA7kwHPsTqA==",
         "dependencies": {
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Quartz.Serialization.SystemTextJson": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "QfqaugT/yokgUGhSrWHIpEGBUOhs0KJKZEd0WLIEoOj7m/eourC495pz1S/vq3I8LN81k6n8Pn6oky8qr3P2iw==",
+        "resolved": "3.18.2",
+        "contentHash": "FZAV4mUwnl4yNSa73ZuQNvBOZeyuPTUW4M8Mxa0XAFHUwgHGEYmqOVSgaztAET+a/fUGNBzj0eEPW2pZMQPYuA==",
         "dependencies": {
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Semver": {
@@ -858,7 +858,7 @@
           "FastEndpoints.Swagger": "[8.1.0, )",
           "Polly": "[8.6.5, )",
           "Polly.Core": "[8.6.6, )",
-          "Quartz.Serialization.SystemTextJson": "[3.17.0, )",
+          "Quartz.Serialization.SystemTextJson": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -878,7 +878,7 @@
       "Reaparr.Application.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },
@@ -886,7 +886,7 @@
         "type": "Project",
         "dependencies": {
           "Autofac.Extras.Quartz": "[11.0.0, )",
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -898,7 +898,7 @@
       "Reaparr.BackgroundJobs.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },

--- a/src/AppHost/packages.lock.json
+++ b/src/AppHost/packages.lock.json
@@ -121,19 +121,19 @@
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "6PBrhEH4S0t5T0DFZgmxPB7jXsEhkxaI6EY6Qt0r9NzOM8S0ukGcnROfPfgMkh7bpqZt/yhD4T7G2ObGBADhMA==",
+        "resolved": "0.6.0",
+        "contentHash": "hhhg6TeGEl5qczPD67xhJ9IYCpZ7PAd6CNiaA9vqK9a8y9tdXUp/Nkca19oTs55BxF8mmNSNUTjnO4T7lhKnvQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "8.0.11"
+          "Microsoft.EntityFrameworkCore": "10.0.8"
         }
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "ZzZScJNxyUuijtf0bl0rN6/MSoqeFa4f+4zbntZCDUy0zMBCs6bw4UoJbOtWwarn9xDgZiw6lanGmuKe0/YbkA==",
+        "resolved": "0.6.0",
+        "contentHash": "gyRyO8EFn3u0AmnJCBBVDzjSKwfJUkrMIFWHL7ox/tp5buezNjWb7K6pyM33wkRRbSvhNqKSQhjoYYkSwPsBMw==",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.5.2",
-          "Microsoft.EntityFrameworkCore.Sqlite": "8.0.11"
+          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.6.0",
+          "Microsoft.EntityFrameworkCore.Sqlite": "10.0.8"
         }
       },
       "Autofac": {
@@ -905,7 +905,7 @@
       "Reaparr.Data": {
         "type": "Project",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.5.2, )",
+          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.6.0, )",
           "Autofac": "[9.1.0, )",
           "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.Data.Sqlite": "[10.0.9, )",

--- a/src/Application.Contracts/Application.Contracts.csproj
+++ b/src/Application.Contracts/Application.Contracts.csproj
@@ -14,7 +14,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Quartz" Version="3.17.0" />
+        <PackageReference Include="Quartz" Version="3.18.2" />
     </ItemGroup>
     <ItemGroup>
         <Using Include="FastEndpoints" />

--- a/src/Application.Contracts/packages.lock.json
+++ b/src/Application.Contracts/packages.lock.json
@@ -10,12 +10,9 @@
       },
       "Quartz": {
         "type": "Direct",
-        "requested": "[3.17.0, )",
-        "resolved": "3.17.0",
-        "contentHash": "Ko3I49Yz1DqlxWi+fXqdG0FYJlHyGnra86m9RSlhPjIoXy7ip8FxyYJ70HcHc5s3xije0QvX81qG2dlxLEI7hQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "2.1.1"
-        }
+        "requested": "[3.18.2, )",
+        "resolved": "3.18.2",
+        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA=="
       },
       "Autofac": {
         "type": "Transitive",
@@ -41,28 +38,19 @@
       "FastEndpoints.Attributes": {
         "type": "Transitive",
         "resolved": "8.1.0",
-        "contentHash": "jo2pRdwv/Bs0JE7S3bCUBZWuyX7u3fJylOf985/epr/tSQfuaBCIwx9XouuXcU00H1XdukcDKUzVmPQFeRZuRg==",
-        "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.5"
-        }
+        "contentHash": "jo2pRdwv/Bs0JE7S3bCUBZWuyX7u3fJylOf985/epr/tSQfuaBCIwx9XouuXcU00H1XdukcDKUzVmPQFeRZuRg=="
       },
       "FastEndpoints.Core": {
         "type": "Transitive",
         "resolved": "8.1.0",
-        "contentHash": "z5Ym1UNtHZ87u5ZsTgajeM+anU1Ab3TsKvFTK5taPTqb89seB2raxFcykhOHoQ9o1hN7gVj3epS8R7ZYx47nhg==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Http.Abstractions": "2.3.9",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
-        }
+        "contentHash": "z5Ym1UNtHZ87u5ZsTgajeM+anU1Ab3TsKvFTK5taPTqb89seB2raxFcykhOHoQ9o1hN7gVj3epS8R7ZYx47nhg=="
       },
       "FastEndpoints.JobQueues": {
         "type": "Transitive",
         "resolved": "8.1.0",
         "contentHash": "vP+D3+4J35miQ2E5mWjay5PDWSPwmlgjvvWFaptNzq0Csde/ONh8PJ8EDnuJ9uhAkKd6QLgujbRaympBQXBhXg==",
         "dependencies": {
-          "FastEndpoints.Messaging": "8.1.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.5"
+          "FastEndpoints.Messaging": "8.1.0"
         }
       },
       "FastEndpoints.Messaging": {
@@ -71,8 +59,7 @@
         "contentHash": "soymzIpNTRjUbrbHZ+418EhB+KC39xj98EWQo8Q0V793EYrl/qVqTlAlahXhInA75CP9pip0/Hgb79U05hflZA==",
         "dependencies": {
           "FastEndpoints.Core": "8.1.0",
-          "FastEndpoints.Messaging.Core": "8.1.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+          "FastEndpoints.Messaging.Core": "8.1.0"
         }
       },
       "FastEndpoints.Messaging.Core": {
@@ -83,11 +70,7 @@
       "FluentResults": {
         "type": "Transitive",
         "resolved": "4.0.0",
-        "contentHash": "wKfdLvDnDVhXlSreU7u/NFNHH6EfoOhAloEID4ePAyk+ZliowKZJvX+aCL4hxhFc9Jj74t62amS4LyOYTjXGCg==",
-        "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "2.1.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
-        }
+        "contentHash": "wKfdLvDnDVhXlSreU7u/NFNHH6EfoOhAloEID4ePAyk+ZliowKZJvX+aCL4hxhFc9Jj74t62amS4LyOYTjXGCg=="
       },
       "FluentValidation": {
         "type": "Transitive",
@@ -103,87 +86,6 @@
         "type": "Transitive",
         "resolved": "2025.2.4",
         "contentHash": "TwbgxAkXxY+vNEhNVx/QXjJ4vqxmepOjsgRvvImQPbHkHMMb4W+ahL3laMsxXKtNT7iMy+E1B3xkqao2hf1n3A=="
-      },
-      "Microsoft.AspNetCore.Http.Abstractions": {
-        "type": "Transitive",
-        "resolved": "2.3.9",
-        "contentHash": "ULScB/0S9+qvf+yahjR+oQUp0GrvoDHJ9XS5gTqSjLjbjUDnHaJ1s8wo3RJMpaDfb1bawX4OgQM+YmvCUveR4Q==",
-        "dependencies": {
-          "Microsoft.AspNetCore.Http.Features": "2.3.0",
-          "System.Text.Encodings.Web": "8.0.0"
-        }
-      },
-      "Microsoft.AspNetCore.Http.Features": {
-        "type": "Transitive",
-        "resolved": "2.3.0",
-        "contentHash": "f10WUgcsKqrkmnz6gt8HeZ7kyKjYN30PO7cSic1lPtH7paPtnQqXPOveul/SIPI43PhRD4trttg4ywnrEmmJpA==",
-        "dependencies": {
-          "Microsoft.Extensions.Primitives": "8.0.0"
-        }
-      },
-      "Microsoft.Extensions.Configuration.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "P09QpTHjqHmCLQOTC+WyLkoRNxek4NIvfWt+TnU0etoDUSRxcltyd6+j/ouRbMdLR0j44GqGO+lhI2M4fAHG4g==",
-        "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "iVMtq9eRvzyhx8949EGT0OCYJfXi737SbRVzWXE5GrOgGj5AaZ9eUuxA/BSUfmOMALKn/g8KfFaNQw0eiB3lyA=="
-      },
-      "Microsoft.Extensions.Diagnostics.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "/nYGrpa9/0BZofrVpBbbj+Ns8ZesiPE0V/KxsuHgDgHQopIzN54nRaQGSuvPw16/kI9sW1Zox5yyAPqvf0Jz6A==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Options": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.FileProviders.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "nCBmCx0Xemlu65ZiWMcXbvfvtznKxf4/YYKF9R28QkqdI9lTikedGqzJ28/xmdGGsxUnsP5/3TQGpiPwVjK0dA==",
-        "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.Hosting.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "+Wb7KAMVZTomwJkQrjuPTe5KBzGod7N8XeG+ScxRlkPOB4sZLG4ccVwjV4Phk5BCJt7uIMnGHVoN6ZMVploX+g==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.Logging.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "9HOdqlDtPptVcmKAjsQ/Nr5Rxfq6FMYLdhvZh1lVmeKR738qeYecQD7+ldooXf+u2KzzR1kafSphWngIM3C6ug==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.Options": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "MDaQMdUplw0AIRhWWmbLA7yQEXaLIHb+9CTroTiNS8OlI0LMXS4LCxtopqauiqGCWlRgJ+xyraVD8t6veRAFbw==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Primitives": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.Primitives": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "/HUHJ0tw/LQvD0DZrz50eQy/3z7PfX7WWEaXnjKTV9/TNdcgFlNTZGo49QhS7PTmhDqMyHRMqAXSBxLh0vso4g=="
       },
       "NaturalSort.Extension": {
         "type": "Transitive",
@@ -260,14 +162,8 @@
         "contentHash": "jGedEvMtohtUTmRix+P4aR7bsz9h+LqCIrF9oBPz90Q68r2pCeXkipWD3dvLopTFsNWSJDHlZpkosPy/xFUshg==",
         "dependencies": {
           "Serilog": "3.1.1",
-          "System.Collections.Immutable": "8.0.0",
           "System.Reactive": "6.0.1"
         }
-      },
-      "System.Collections.Immutable": {
-        "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg=="
       },
       "System.ComponentModel.Annotations": {
         "type": "Transitive",
@@ -278,16 +174,6 @@
         "type": "Transitive",
         "resolved": "6.1.0",
         "contentHash": "M5cCC1ZMkZr9jbSQGTHnVkb5TDN67qWCV7AP8TAHdGkvDlu0puT5NzemESNn9+HkYIDpWpocP68/i+/ame2/2w=="
-      },
-      "System.Text.Encodings.Web": {
-        "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "yev/k9GHAEGx2Rg3/tU6MQh4HGBXJs70y7j1LaM1i/ER9po+6nnQ6RRqTJn1E7Xu0fbIFK80Nh5EoODxrbxwBQ=="
-      },
-      "System.Threading.Tasks.Extensions": {
-        "type": "Transitive",
-        "resolved": "4.5.4",
-        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg=="
       },
       "Xdg.Directories": {
         "type": "Transitive",
@@ -329,7 +215,6 @@
         "dependencies": {
           "Autofac": "[9.1.0, )",
           "FluentResults": "[4.0.0, )",
-          "Microsoft.AspNetCore.Http.Abstractions": "[2.3.9, )",
           "Reaparr.Environment": "[1.0.0, )",
           "Serilog": "[4.3.1, )",
           "Serilog.Enrichers.Sensitive": "[2.1.0, )",

--- a/src/Application/Application.csproj
+++ b/src/Application/Application.csproj
@@ -15,7 +15,7 @@
         <PackageReference Include="FastEndpoints.Swagger" Version="8.1.0" />
         <PackageReference Include="Polly" Version="8.6.5" />
         <PackageReference Include="Polly.Core" Version="8.6.6" />
-        <PackageReference Include="Quartz.Serialization.SystemTextJson" Version="3.17.0" />
+        <PackageReference Include="Quartz.Serialization.SystemTextJson" Version="3.18.2" />
         <PackageReference Include="Semver" Version="3.0.0" />
         <PackageReference Include="Velopack" Version="0.0.1298" />
     </ItemGroup>

--- a/src/Application/PlexServerConnection/CheckAllConnectionsByServer/CheckAllConnectionsStatusByPlexServerCommand.cs
+++ b/src/Application/PlexServerConnection/CheckAllConnectionsByServer/CheckAllConnectionsStatusByPlexServerCommand.cs
@@ -6,7 +6,8 @@ namespace Reaparr.Application;
 /// </summary>
 /// <param name="PlexServerId">The id of the <see cref="PlexServer" /> to check the connections for.</param>
 /// <returns>Returns successful result if any connection connected.</returns>
-public record CheckAllConnectionsStatusByPlexServerCommand(int PlexServerId) : ICommand<Result<List<PlexServerStatus>>>;
+public record CheckAllConnectionsStatusByPlexServerCommand(int PlexServerId, int Timeout = 10)
+    : ICommand<Result<List<PlexServerStatus>>>;
 
 public class CheckAllConnectionsStatusByPlexServerValidator
     : AbstractValidator<CheckAllConnectionsStatusByPlexServerCommand>
@@ -14,6 +15,7 @@ public class CheckAllConnectionsStatusByPlexServerValidator
     public CheckAllConnectionsStatusByPlexServerValidator()
     {
         RuleFor(x => x.PlexServerId).GreaterThan(0);
+        RuleFor(x => x.Timeout).GreaterThan(0);
     }
 }
 
@@ -74,7 +76,7 @@ public class CheckAllConnectionsStatusByPlexServerHandler
         // Create connection check tasks for all connections
         var connectionTasks = connections.Select(async plexServerConnection =>
             await _commandExecutor.Send(
-                new CheckConnectionStatusByIdCommand(plexServerConnection.Id),
+                new CheckConnectionStatusByIdCommand(plexServerConnection.Id, command.Timeout),
                 cancellationToken
             )
         );

--- a/src/Application/PlexServerConnection/CheckConnectionStatus/CheckConnectionStatusByIdCommand.cs
+++ b/src/Application/PlexServerConnection/CheckConnectionStatus/CheckConnectionStatusByIdCommand.cs
@@ -1,12 +1,14 @@
 namespace Reaparr.Application;
 
-public record CheckConnectionStatusByIdCommand(int PlexServerConnectionId) : ICommand<Result<PlexServerStatus>>;
+public record CheckConnectionStatusByIdCommand(int PlexServerConnectionId, int Timeout = 10)
+    : ICommand<Result<PlexServerStatus>>;
 
 public class CheckConnectionStatusByIdCommandValidator : AbstractValidator<CheckConnectionStatusByIdCommand>
 {
     public CheckConnectionStatusByIdCommandValidator()
     {
         RuleFor(x => x.PlexServerConnectionId).GreaterThan(0);
+        RuleFor(x => x.Timeout).GreaterThan(0);
     }
 }
 
@@ -59,6 +61,7 @@ public class CheckConnectionStatusByIdCommandHandler
             new GetServerStatusCommand
             {
                 PlexServerConnectionId = command.PlexServerConnectionId,
+                Timeout = command.Timeout,
                 ProgressAction = progress =>
                 {
                     if (_plexServerConnection is not null)

--- a/src/Application/PlexServers/InspectPlexServer/InspectPlexServerJob.cs
+++ b/src/Application/PlexServers/InspectPlexServer/InspectPlexServerJob.cs
@@ -7,7 +7,7 @@ public class InspectPlexServerJob : IJob
 {
     public static string PlexServerIdsParameter => "plexServerIds";
 
-    private readonly IReaparrDbContext _dbContext;
+    private readonly IReaparrDbContextFactory _dbContextFactory;
     private readonly INotificationHubService _notificationHubService;
     private readonly ILogger _log;
     private readonly ICommandExecutor _commandExecutor;
@@ -17,13 +17,13 @@ public class InspectPlexServerJob : IJob
     public InspectPlexServerJob(
         ILogger log,
         ICommandExecutor commandExecutor,
-        IReaparrDbContext dbContext,
+        IReaparrDbContextFactory dbContextFactory,
         INotificationHubService notificationHubService
     )
     {
         _log = log.ForContext<InspectPlexServerJob>();
         _commandExecutor = commandExecutor;
-        _dbContext = dbContext;
+        _dbContextFactory = dbContextFactory;
         _notificationHubService = notificationHubService;
     }
 
@@ -43,20 +43,7 @@ public class InspectPlexServerJob : IJob
 
         try
         {
-            var serverTasks = plexServerIds.Select(async plexServerId =>
-            {
-                // Check all Plex Server Connections
-                var checkResult = await _commandExecutor.Send(
-                    new CheckAllConnectionsStatusByPlexServerCommand(plexServerId),
-                    cancellationToken
-                );
-
-                if (checkResult.IsFailed)
-                    return checkResult.LogError();
-
-                return await RefreshAndSyncLibraries(plexServerId, cancellationToken);
-            });
-
+            var serverTasks = plexServerIds.Select(plexServerId => InspectPlexServer(plexServerId, cancellationToken));
             await Task.WhenAll(serverTasks);
 
             _log.Here().Information("Successfully finished the inspection of {Count}", plexServerIds.Count);
@@ -69,10 +56,32 @@ public class InspectPlexServerJob : IJob
         }
     }
 
-    private async Task<Result> RefreshAndSyncLibraries(int plexServerId, CancellationToken cancellationToken)
+    private async Task InspectPlexServer(int plexServerId, CancellationToken cancellationToken)
+    {
+        // Check all Plex Server Connections
+        var checkResult = await _commandExecutor.Send(
+            new CheckAllConnectionsStatusByPlexServerCommand(plexServerId),
+            cancellationToken
+        );
+
+        if (checkResult.IsFailed)
+        {
+            checkResult.LogError();
+            return;
+        }
+
+        using var dbContext = await _dbContextFactory.CreateAsync();
+        await RefreshAndSyncLibraries(dbContext, plexServerId, cancellationToken);
+    }
+
+    private async Task<Result> RefreshAndSyncLibraries(
+        IReaparrDbContext dbContext,
+        int plexServerId,
+        CancellationToken cancellationToken
+    )
     {
         // Refresh accessible libraries
-        var accountsResult = await _dbContext.GetPlexAccountsWithAccessAsync(plexServerId, cancellationToken);
+        var accountsResult = await dbContext.GetPlexAccountsWithAccessAsync(plexServerId, cancellationToken);
         if (accountsResult.IsFailed)
             return accountsResult.ToResult().LogError();
 
@@ -85,7 +94,7 @@ public class InspectPlexServerJob : IJob
             CancellationToken.None
         );
 
-        var libraryIds = await _dbContext
+        var libraryIds = await dbContext
             .PlexLibraries.Where(x => x.PlexServerId == plexServerId)
             .Select(x => x.Id)
             .ToListAsync(cancellationToken);

--- a/src/Application/PlexServers/InspectPlexServer/InspectPlexServerJob.cs
+++ b/src/Application/PlexServers/InspectPlexServer/InspectPlexServerJob.cs
@@ -60,7 +60,7 @@ public class InspectPlexServerJob : IJob
     {
         // Check all Plex Server Connections
         var checkResult = await _commandExecutor.Send(
-            new CheckAllConnectionsStatusByPlexServerCommand(plexServerId),
+            new CheckAllConnectionsStatusByPlexServerCommand(plexServerId, Timeout: 5),
             cancellationToken
         );
 

--- a/src/Application/_Shared/Config/Autofac/QuartzModule.cs
+++ b/src/Application/_Shared/Config/Autofac/QuartzModule.cs
@@ -8,6 +8,9 @@ namespace Reaparr.Application;
 
 public class QuartzModule : Module
 {
+    private static readonly string _connectionProviderTypeName =
+        $"{typeof(QuartzSqliteConnectionProvider).FullName}, {typeof(QuartzSqliteConnectionProvider).Assembly.GetName().Name}";
+
     protected override void Load(ContainerBuilder builder)
     {
         var assembly = Assembly.GetExecutingAssembly();
@@ -36,7 +39,14 @@ public class QuartzModule : Module
                         { "quartz.jobStore.tablePrefix", "QRTZ_" },
                         // { "quartz.jobStore.useProperties", "true" },
                         { "quartz.jobStore.driverDelegateType", "Quartz.Impl.AdoJobStore.SQLiteDelegate, Quartz" },
-                        { "quartz.dataSource.default.provider", "SQLite-Microsoft" },
+                        {
+                            "quartz.dataSource.default.connectionProvider.type",
+                            _connectionProviderTypeName
+                        },
+                        {
+                            "quartz.dataSource.default.connectionProvider.connectionString",
+                            DbContextConnections.GetConnectionString(pathProvider)
+                        },
                         // False because we are first setting up autofac, and then the database. When the database is set up, the schema is already validated.
                         { "quartz.jobStore.performSchemaValidation", "false" },
                         {

--- a/src/Application/_Shared/Config/Quartz/QuartzSqliteConnectionProvider.cs
+++ b/src/Application/_Shared/Config/Quartz/QuartzSqliteConnectionProvider.cs
@@ -1,15 +1,13 @@
 using System.Data;
 using System.Data.Common;
-using EntityFrameworkCore.Sqlite.Concurrency;
 using Microsoft.Data.Sqlite;
 using Quartz.Impl.AdoJobStore.Common;
 
 namespace Reaparr.Application;
 
 /// <summary>
-/// Custom Quartz <see cref="IDbProvider"/> that applies the same SQLite PRAGMAs
-/// (<c>busy_timeout</c>, <c>journal_mode=WAL</c>, <c>synchronous=NORMAL</c>, etc.)
-/// as the EF Core pipeline via <see cref="SqliteConnectionEnhancer.ApplyRuntimePragmas"/>.
+/// Custom Quartz <see cref="IDbProvider"/> that applies <c>PRAGMA busy_timeout</c>
+/// to every connection opened by Quartz's <c>AdoJobStore</c>.
 ///
 /// Quartz's <c>AdoJobStore</c> opens raw ADO.NET connections that bypass the EF Core
 /// interceptor pipeline. Without this provider, Quartz connections get <c>busy_timeout=0</c>
@@ -19,9 +17,6 @@ namespace Reaparr.Application;
 /// </summary>
 public sealed class QuartzSqliteConnectionProvider : IDbProvider
 {
-    private const string MetadataProductName = "Quartz-SQLite-Custom";
-    private const string MetadataAssemblyName = "Microsoft.Data.Sqlite";
-
     private readonly DbProviderFactory _factory;
     private string _connectionString = "";
 
@@ -50,8 +45,11 @@ public sealed class QuartzSqliteConnectionProvider : IDbProvider
     /// <inheritdoc />
     public DbMetadata Metadata => new()
     {
-        ProductName = MetadataProductName,
-        AssemblyName = MetadataAssemblyName,
+        ProductName = "Microsoft.Data.Sqlite",
+        AssemblyName = "Microsoft.Data.Sqlite",
+        ParameterNamePrefix = "@",
+        BindByName = true,
+        UseParameterNamePrefixInParameterCollection = true,
     };
 
     /// <inheritdoc />
@@ -77,7 +75,11 @@ public sealed class QuartzSqliteConnectionProvider : IDbProvider
         conn.StateChange += (_, args) =>
         {
             if (args.CurrentState == ConnectionState.Open)
-                SqliteConnectionEnhancer.ApplyRuntimePragmas(conn);
+            {
+                using var pragmaCmd = conn.CreateCommand();
+                pragmaCmd.CommandText = "PRAGMA busy_timeout = 30000;";
+                pragmaCmd.ExecuteNonQuery();
+            }
         };
 
         return conn;

--- a/src/Application/_Shared/Config/Quartz/QuartzSqliteConnectionProvider.cs
+++ b/src/Application/_Shared/Config/Quartz/QuartzSqliteConnectionProvider.cs
@@ -6,14 +6,15 @@ using Quartz.Impl.AdoJobStore.Common;
 namespace Reaparr.Application;
 
 /// <summary>
-/// Custom Quartz <see cref="IDbProvider"/> that applies <c>PRAGMA busy_timeout</c>
-/// to every connection opened by Quartz's <c>AdoJobStore</c>.
+/// Custom Quartz <see cref="IDbProvider"/> that applies SQLite PRAGMAs
+/// to every connection opened by Quartz's <c>AdoJobStore</c>, matching the
+/// EF Core concurrency interceptor's connection-level defaults.
 ///
 /// Quartz's <c>AdoJobStore</c> opens raw ADO.NET connections that bypass the EF Core
-/// interceptor pipeline. Without this provider, Quartz connections get <c>busy_timeout=0</c>
-/// (the SQLite default), which causes instant <c>SQLITE_BUSY</c> ("database is locked")
-/// whenever an EF Core write transaction holds the lock — most commonly observed during
-/// misfire recovery.
+/// interceptor pipeline. Without this provider, Quartz connections get factory-default
+/// settings — including <c>busy_timeout=0</c> (the SQLite default), which causes instant
+/// <c>SQLITE_BUSY</c> ("database is locked") whenever an EF Core write transaction holds
+/// the lock — most commonly observed during misfire recovery.
 /// </summary>
 public sealed class QuartzSqliteConnectionProvider : IDbProvider
 {
@@ -77,7 +78,16 @@ public sealed class QuartzSqliteConnectionProvider : IDbProvider
             if (args.CurrentState == ConnectionState.Open)
             {
                 using var pragmaCmd = conn.CreateCommand();
-                pragmaCmd.CommandText = "PRAGMA busy_timeout = 30000;";
+                pragmaCmd.CommandText = """
+                    PRAGMA journal_mode = WAL;
+                    PRAGMA synchronous = NORMAL;
+                    PRAGMA busy_timeout = 30000;
+                    PRAGMA cache_size = -20000;
+                    PRAGMA mmap_size = 268435456;
+                    PRAGMA temp_store = MEMORY;
+                    PRAGMA locking_mode = NORMAL;
+                    PRAGMA secure_delete = OFF;
+                    """;
                 pragmaCmd.ExecuteNonQuery();
             }
         };

--- a/src/Application/_Shared/Config/Quartz/QuartzSqliteConnectionProvider.cs
+++ b/src/Application/_Shared/Config/Quartz/QuartzSqliteConnectionProvider.cs
@@ -1,0 +1,85 @@
+using System.Data;
+using System.Data.Common;
+using EntityFrameworkCore.Sqlite.Concurrency;
+using Microsoft.Data.Sqlite;
+using Quartz.Impl.AdoJobStore.Common;
+
+namespace Reaparr.Application;
+
+/// <summary>
+/// Custom Quartz <see cref="IDbProvider"/> that applies the same SQLite PRAGMAs
+/// (<c>busy_timeout</c>, <c>journal_mode=WAL</c>, <c>synchronous=NORMAL</c>, etc.)
+/// as the EF Core pipeline via <see cref="SqliteConnectionEnhancer.ApplyRuntimePragmas"/>.
+///
+/// Quartz's <c>AdoJobStore</c> opens raw ADO.NET connections that bypass the EF Core
+/// interceptor pipeline. Without this provider, Quartz connections get <c>busy_timeout=0</c>
+/// (the SQLite default), which causes instant <c>SQLITE_BUSY</c> ("database is locked")
+/// whenever an EF Core write transaction holds the lock — most commonly observed during
+/// misfire recovery.
+/// </summary>
+public sealed class QuartzSqliteConnectionProvider : IDbProvider
+{
+    private const string MetadataProductName = "Quartz-SQLite-Custom";
+    private const string MetadataAssemblyName = "Microsoft.Data.Sqlite";
+
+    private readonly DbProviderFactory _factory;
+    private string _connectionString = "";
+
+    /// <summary>
+    /// Parameterless constructor required by Quartz's reflection-based instantiation
+    /// via <c>ObjectUtils.InstantiateType</c>.
+    /// </summary>
+    public QuartzSqliteConnectionProvider()
+    {
+        _factory = SqliteFactory.Instance;
+    }
+
+    /// <inheritdoc />
+    public void Initialize() { }
+
+    /// <inheritdoc />
+    public void Shutdown() { }
+
+    /// <inheritdoc />
+    public string ConnectionString
+    {
+        get => _connectionString;
+        set => _connectionString = value;
+    }
+
+    /// <inheritdoc />
+    public DbMetadata Metadata => new()
+    {
+        ProductName = MetadataProductName,
+        AssemblyName = MetadataAssemblyName,
+    };
+
+    /// <inheritdoc />
+    public DbCommand CreateCommand()
+    {
+        var cmd = _factory.CreateCommand()
+            ?? throw new InvalidOperationException("SqliteFactory returned null command");
+
+        return cmd;
+    }
+
+    /// <inheritdoc />
+    public DbConnection CreateConnection()
+    {
+        var conn = _factory.CreateConnection()
+            ?? throw new InvalidOperationException("SqliteFactory returned null connection");
+
+        conn.ConnectionString = _connectionString;
+
+        // Quartz calls CreateConnection() then Open(). We hook StateChange
+        // to apply PRAGMAs on every Open() — this is the same pattern as
+        // EF Core's ConnectionOpened interceptor, but for raw ADO.NET.
+        conn.StateChange += (_, args) =>
+        {
+            if (args.CurrentState == ConnectionState.Open)
+                SqliteConnectionEnhancer.ApplyRuntimePragmas(conn);
+        };
+
+        return conn;
+    }
+}

--- a/src/Application/packages.lock.json
+++ b/src/Application/packages.lock.json
@@ -74,11 +74,11 @@
       },
       "Quartz.Serialization.SystemTextJson": {
         "type": "Direct",
-        "requested": "[3.17.0, )",
-        "resolved": "3.17.0",
-        "contentHash": "QfqaugT/yokgUGhSrWHIpEGBUOhs0KJKZEd0WLIEoOj7m/eourC495pz1S/vq3I8LN81k6n8Pn6oky8qr3P2iw==",
+        "requested": "[3.18.2, )",
+        "resolved": "3.18.2",
+        "contentHash": "FZAV4mUwnl4yNSa73ZuQNvBOZeyuPTUW4M8Mxa0XAFHUwgHGEYmqOVSgaztAET+a/fUGNBzj0eEPW2pZMQPYuA==",
         "dependencies": {
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Semver": {
@@ -501,8 +501,8 @@
       },
       "Quartz": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "Ko3I49Yz1DqlxWi+fXqdG0FYJlHyGnra86m9RSlhPjIoXy7ip8FxyYJ70HcHc5s3xije0QvX81qG2dlxLEI7hQ=="
+        "resolved": "3.18.2",
+        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA=="
       },
       "Serilog": {
         "type": "Transitive",
@@ -661,14 +661,14 @@
       "Reaparr.Application.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },
       "Reaparr.BackgroundJobs.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },

--- a/src/BackgroundJobs.Contracts/BackgroundJobs.Contracts.csproj
+++ b/src/BackgroundJobs.Contracts/BackgroundJobs.Contracts.csproj
@@ -11,7 +11,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Quartz" Version="3.17.0" />
+        <PackageReference Include="Quartz" Version="3.18.2" />
     </ItemGroup>
     <ItemGroup>
         <Using Include="FastEndpoints" />

--- a/src/BackgroundJobs.Contracts/packages.lock.json
+++ b/src/BackgroundJobs.Contracts/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Quartz": {
         "type": "Direct",
-        "requested": "[3.17.0, )",
-        "resolved": "3.17.0",
-        "contentHash": "Ko3I49Yz1DqlxWi+fXqdG0FYJlHyGnra86m9RSlhPjIoXy7ip8FxyYJ70HcHc5s3xije0QvX81qG2dlxLEI7hQ==",
+        "requested": "[3.18.2, )",
+        "resolved": "3.18.2",
+        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "2.1.1"
         }

--- a/src/BackgroundJobs/BackgroundJobs.csproj
+++ b/src/BackgroundJobs/BackgroundJobs.csproj
@@ -17,7 +17,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Quartz" Version="3.17.0" />
+        <PackageReference Include="Quartz" Version="3.18.2" />
     </ItemGroup>
     <ItemGroup>
         <Using Include="System.ComponentModel.DataAnnotations" />

--- a/src/BackgroundJobs/LibrarySync/Commands/RefreshLibraryMedia/CRUD/InsertMediaMetaDataCommand.cs
+++ b/src/BackgroundJobs/LibrarySync/Commands/RefreshLibraryMedia/CRUD/InsertMediaMetaDataCommand.cs
@@ -50,8 +50,6 @@ public record InsertMediaMetaDataCommandResponse
 public class InsertMediaMetaDataCommandHandler
     : ICommandHandler<InsertMediaMetaDataCommand, Result<InsertMediaMetaDataCommandResponse>>
 {
-    private const int CHUNK_SIZE = 500;
-
     private readonly ILogger _log;
     private readonly IReaparrDbContext _dbContext;
 
@@ -127,62 +125,11 @@ public class InsertMediaMetaDataCommandHandler
         _log.Here()
             .Debug("Inserting {Count} {NameOfPlexActor} after deduplication", newPlexActors.Count, nameof(PlexActor));
 
-        // Chunk the existingKeys query to avoid hitting SQLite IN-clause parameter limits
-        var incomingKeys = newPlexActors.Select(x => x.Key).ToList();
-        var existingIdByKey = new Dictionary<string, int>(newPlexActors.Count);
-        _log.Here()
-            .Debug(
-                "[InsertMetaData] Starting {ChunkCount} DB chunk queries for actors",
-                (incomingKeys.Count + CHUNK_SIZE - 1) / CHUNK_SIZE
-            );
-        foreach (var chunk in incomingKeys.Chunk(CHUNK_SIZE))
-        {
-            var found = await _dbContext
-                .PlexActors.AsNoTracking()
-                .Where(a => chunk.Contains(a.Key))
-                .Select(a => new { a.Key, a.Id })
-                .ToListAsync(ct);
-            foreach (var a in found)
-                existingIdByKey[a.Key] = a.Id;
-        }
-        _log.Here().Debug("[InsertMetaData] DB chunk queries for actors done");
+        var existingIdByKey = await _dbContext.InsertOrIgnorePlexActorsAsync(newPlexActors, ct);
 
         _log.Here()
             .Debug(
-                "{ExistingCount} {NameOfPlexActor} already exist in DB, inserting {NewCount} new",
-                existingIdByKey.Count,
-                nameof(PlexActor),
-                newPlexActors.Count - existingIdByKey.Count
-            );
-
-        var toInsert = newPlexActors.Where(a => !existingIdByKey.ContainsKey(a.Key)).ToList();
-
-        var insertResult = await Result.Try(async Task () =>
-        {
-            foreach (var chunk in toInsert.Chunk(CHUNK_SIZE))
-            {
-                _dbContext.PlexActors.AddRange(chunk);
-                await _dbContext.SaveChangesNewAsync(ct);
-                foreach (var a in chunk)
-                    existingIdByKey[a.Key] = a.Id;
-                _dbContext.ClearChangeTracker();
-            }
-        });
-
-        if (insertResult.IsFailed)
-        {
-            _log.Here()
-                .Error(
-                    "Failed to insert {NameOfPlexActor} after {ElapsedSeconds:F2} seconds",
-                    nameof(PlexActor),
-                    stopWatch.Elapsed.TotalSeconds
-                );
-            return insertResult.LogError();
-        }
-
-        _log.Here()
-            .Debug(
-                "Finished inserting new {NameOfPlexActor}, now building result dictionary with {TotalCount} total",
+                "Upserted {NameOfPlexActor}, now building result dictionary with {TotalCount} total",
                 nameof(PlexActor),
                 existingIdByKey.Count
             );
@@ -240,51 +187,7 @@ public class InsertMediaMetaDataCommandHandler
         _log.Here()
             .Debug("Inserting {Count} {NameOfPlexGenre} after deduplication", newPlexGenres.Count, nameof(PlexGenre));
 
-        var incomingKeys = newPlexGenres.Select(x => x.Key).ToList();
-        var existingIdByKey = new Dictionary<string, int>(newPlexGenres.Count);
-        foreach (var chunk in incomingKeys.Chunk(CHUNK_SIZE))
-        {
-            var found = await _dbContext
-                .PlexGenres.AsNoTracking()
-                .Where(g => chunk.Contains(g.Key))
-                .Select(g => new { g.Key, g.Id })
-                .ToListAsync(ct);
-            foreach (var g in found)
-                existingIdByKey[g.Key] = g.Id;
-        }
-
-        _log.Here()
-            .Debug(
-                "Found {ExistingCount} existing {NameOfPlexGenre}, will insert {NewCount}",
-                existingIdByKey.Count,
-                nameof(PlexGenre),
-                newPlexGenres.Count - existingIdByKey.Count
-            );
-
-        var toInsert = newPlexGenres.Where(g => !existingIdByKey.ContainsKey(g.Key)).ToList();
-
-        var insertResult = await Result.Try(async Task () =>
-        {
-            foreach (var chunk in toInsert.Chunk(CHUNK_SIZE))
-            {
-                _dbContext.PlexGenres.AddRange(chunk);
-                await _dbContext.SaveChangesNewAsync(ct);
-                foreach (var g in chunk)
-                    existingIdByKey[g.Key] = g.Id;
-                _dbContext.ClearChangeTracker();
-            }
-        });
-
-        if (insertResult.IsFailed)
-        {
-            _log.Here()
-                .Error(
-                    "Failed to insert {NameOfPlexGenre} after {ElapsedSeconds:F2} seconds",
-                    nameof(PlexGenre),
-                    stopWatch.Elapsed.TotalSeconds
-                );
-            return insertResult.LogError();
-        }
+        var existingIdByKey = await _dbContext.InsertOrIgnorePlexGenresAsync(newPlexGenres, ct);
 
         // Build result dictionary from merged Id map — avoids re-fetching all genres from DB
         var result = new Dictionary<string, PlexGenre>(newPlexGenres.Count);
@@ -341,51 +244,7 @@ public class InsertMediaMetaDataCommandHandler
                 nameof(PlexCountry)
             );
 
-        var incomingKeys = newPlexCountries.Select(x => x.Key).ToList();
-        var existingIdByKey = new Dictionary<string, int>(newPlexCountries.Count);
-        foreach (var chunk in incomingKeys.Chunk(CHUNK_SIZE))
-        {
-            var found = await _dbContext
-                .PlexCountries.AsNoTracking()
-                .Where(c => chunk.Contains(c.Key))
-                .Select(c => new { c.Key, c.Id })
-                .ToListAsync(ct);
-            foreach (var c in found)
-                existingIdByKey[c.Key] = c.Id;
-        }
-
-        _log.Here()
-            .Debug(
-                "Found {ExistingCount} existing {NameOfPlexCountry}, will insert {NewCount}",
-                existingIdByKey.Count,
-                nameof(PlexCountry),
-                newPlexCountries.Count - existingIdByKey.Count
-            );
-
-        var toInsert = newPlexCountries.Where(c => !existingIdByKey.ContainsKey(c.Key)).ToList();
-
-        var insertResult = await Result.Try(async Task () =>
-        {
-            foreach (var chunk in toInsert.Chunk(CHUNK_SIZE))
-            {
-                _dbContext.PlexCountries.AddRange(chunk);
-                await _dbContext.SaveChangesNewAsync(ct);
-                foreach (var c in chunk)
-                    existingIdByKey[c.Key] = c.Id;
-                _dbContext.ClearChangeTracker();
-            }
-        });
-
-        if (insertResult.IsFailed)
-        {
-            _log.Here()
-                .Error(
-                    "Failed to insert {NameOfPlexCountry} after {ElapsedSeconds:F2} seconds",
-                    nameof(PlexCountry),
-                    stopWatch.Elapsed.TotalSeconds
-                );
-            return insertResult.LogError();
-        }
+        var existingIdByKey = await _dbContext.InsertOrIgnorePlexCountriesAsync(newPlexCountries, ct);
 
         // Build result dictionary from merged Id map — avoids re-fetching all countries from DB
         var result = new Dictionary<string, PlexCountry>(newPlexCountries.Count);

--- a/src/BackgroundJobs/packages.lock.json
+++ b/src/BackgroundJobs/packages.lock.json
@@ -21,9 +21,9 @@
       },
       "Quartz": {
         "type": "Direct",
-        "requested": "[3.17.0, )",
-        "resolved": "3.17.0",
-        "contentHash": "Ko3I49Yz1DqlxWi+fXqdG0FYJlHyGnra86m9RSlhPjIoXy7ip8FxyYJ70HcHc5s3xije0QvX81qG2dlxLEI7hQ==",
+        "requested": "[3.18.2, )",
+        "resolved": "3.18.2",
+        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "2.1.1"
         }
@@ -523,14 +523,14 @@
       "Reaparr.Application.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },
       "Reaparr.BackgroundJobs.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },

--- a/src/Data.Contracts/Extensions/DbContext/DbContextExtensions.PlexMetaData.cs
+++ b/src/Data.Contracts/Extensions/DbContext/DbContextExtensions.PlexMetaData.cs
@@ -1,0 +1,92 @@
+using System.Text;
+using EntityFrameworkCore.Sqlite.Concurrency;
+
+namespace Reaparr.Data.Contracts;
+
+public static partial class DbContextExtensions
+{
+    private const int CHUNK_SIZE = 500;
+
+    public static async Task<int> InsertOrIgnorePlexActorsAsync(
+        this IReaparrDbContext dbContext,
+        IReadOnlyCollection<PlexActor> entities,
+        CancellationToken ct)
+    {
+        var count = 0;
+
+        foreach (var chunk in entities.Chunk(CHUNK_SIZE))
+        {
+            await ((DbContext)dbContext).ExecuteWithRetryAsync(async db =>
+            {
+                var query = new StringBuilder();
+                foreach (var actor in chunk)
+                {
+                    query.AppendLine(
+                        $"INSERT OR IGNORE INTO PlexActors (Name, Key) VALUES ('{Escape(actor.Name)}', '{Escape(actor.Key)}');");
+                }
+
+                count += await db.Database.ExecuteSqlRawAsync(query.ToString(), ct);
+
+                return true;
+            }, cancellationToken: ct);
+        }
+
+        return count;
+    }
+
+    public static async Task<int> InsertOrIgnorePlexGenresAsync(
+        this IReaparrDbContext dbContext,
+        IReadOnlyCollection<PlexGenre> entities,
+        CancellationToken ct)
+    {
+        var count = 0;
+
+        foreach (var chunk in entities.Chunk(CHUNK_SIZE))
+        {
+            await ((DbContext)dbContext).ExecuteWithRetryAsync(async db =>
+            {
+                var query = new StringBuilder();
+                foreach (var genre in chunk)
+                {
+                    query.AppendLine(
+                        $"INSERT OR IGNORE INTO PlexGenres (Name, Key) VALUES ('{Escape(genre.Name)}', '{Escape(genre.Key)}');");
+                }
+
+                count += await db.Database.ExecuteSqlRawAsync(query.ToString(), ct);
+
+                return true;
+            }, cancellationToken: ct);
+        }
+
+        return count;
+    }
+
+    public static async Task<int> InsertOrIgnorePlexCountriesAsync(
+        this IReaparrDbContext dbContext,
+        IReadOnlyCollection<PlexCountry> entities,
+        CancellationToken ct)
+    {
+        var count = 0;
+
+        foreach (var chunk in entities.Chunk(CHUNK_SIZE))
+        {
+            await ((DbContext)dbContext).ExecuteWithRetryAsync(async db =>
+            {
+                var query = new StringBuilder();
+                foreach (var country in chunk)
+                {
+                    query.AppendLine(
+                        $"INSERT OR IGNORE INTO PlexCountries (Name, Key) VALUES ('{Escape(country.Name)}', '{Escape(country.Key)}');");
+                }
+
+                count += await db.Database.ExecuteSqlRawAsync(query.ToString(), ct);
+
+                return true;
+            }, cancellationToken: ct);
+        }
+
+        return count;
+    }
+
+    private static string Escape(string value) => value.Replace("'", "''");
+}

--- a/src/Data.Contracts/Extensions/DbContext/DbContextExtensions.PlexMetaData.cs
+++ b/src/Data.Contracts/Extensions/DbContext/DbContextExtensions.PlexMetaData.cs
@@ -1,92 +1,130 @@
-using System.Text;
+using System.Runtime.CompilerServices;
 using EntityFrameworkCore.Sqlite.Concurrency;
 
 namespace Reaparr.Data.Contracts;
 
 public static partial class DbContextExtensions
 {
-    private const int CHUNK_SIZE = 500;
+    private const int CHUNK_SIZE = 400;
 
-    public static async Task<int> InsertOrIgnorePlexActorsAsync(
+    public static async Task<Dictionary<string, int>> InsertOrIgnorePlexActorsAsync(
         this IReaparrDbContext dbContext,
         IReadOnlyCollection<PlexActor> entities,
         CancellationToken ct)
     {
-        var count = 0;
+        var result = new Dictionary<string, int>(entities.Count);
 
         foreach (var chunk in entities.Chunk(CHUNK_SIZE))
         {
+            var arguments = new List<object>(chunk.Length * 2);
+            var values = new List<string>(chunk.Length);
+            foreach (var actor in chunk)
+            {
+                values.Add($"({{{arguments.Count}}}, {{{arguments.Count + 1}}})");
+                arguments.Add(actor.Name);
+                arguments.Add(actor.Key);
+            }
+
+            var sql = FormattableStringFactory.Create(
+                $"INSERT OR IGNORE INTO PlexActors (Name, Key) VALUES {string.Join(", ", values)}",
+                arguments.ToArray()
+            );
+
             await ((DbContext)dbContext).ExecuteWithRetryAsync(async db =>
             {
-                var query = new StringBuilder();
-                foreach (var actor in chunk)
-                {
-                    query.AppendLine(
-                        $"INSERT OR IGNORE INTO PlexActors (Name, Key) VALUES ('{Escape(actor.Name)}', '{Escape(actor.Key)}');");
-                }
-
-                count += await db.Database.ExecuteSqlRawAsync(query.ToString(), ct);
-
+                await db.Database.ExecuteSqlInterpolatedAsync(sql, ct);
                 return true;
             }, cancellationToken: ct);
+
+            var keys = chunk.Select(a => a.Key).ToList();
+            var found = await dbContext.PlexActors
+                .Where(a => keys.Contains(a.Key))
+                .Select(a => new { a.Key, a.Id })
+                .ToListAsync(ct);
+            foreach (var a in found)
+                result[a.Key] = a.Id;
         }
 
-        return count;
+        return result;
     }
 
-    public static async Task<int> InsertOrIgnorePlexGenresAsync(
+    public static async Task<Dictionary<string, int>> InsertOrIgnorePlexGenresAsync(
         this IReaparrDbContext dbContext,
         IReadOnlyCollection<PlexGenre> entities,
         CancellationToken ct)
     {
-        var count = 0;
+        var result = new Dictionary<string, int>(entities.Count);
 
         foreach (var chunk in entities.Chunk(CHUNK_SIZE))
         {
+            var arguments = new List<object>(chunk.Length * 2);
+            var values = new List<string>(chunk.Length);
+            foreach (var genre in chunk)
+            {
+                values.Add($"({{{arguments.Count}}}, {{{arguments.Count + 1}}})");
+                arguments.Add(genre.Name);
+                arguments.Add(genre.Key);
+            }
+
+            var sql = FormattableStringFactory.Create(
+                $"INSERT OR IGNORE INTO PlexGenres (Name, Key) VALUES {string.Join(", ", values)}",
+                arguments.ToArray()
+            );
             await ((DbContext)dbContext).ExecuteWithRetryAsync(async db =>
             {
-                var query = new StringBuilder();
-                foreach (var genre in chunk)
-                {
-                    query.AppendLine(
-                        $"INSERT OR IGNORE INTO PlexGenres (Name, Key) VALUES ('{Escape(genre.Name)}', '{Escape(genre.Key)}');");
-                }
-
-                count += await db.Database.ExecuteSqlRawAsync(query.ToString(), ct);
-
+                await db.Database.ExecuteSqlInterpolatedAsync(sql, ct);
                 return true;
             }, cancellationToken: ct);
+
+            var keys = chunk.Select(g => g.Key).ToList();
+            var found = await dbContext.PlexGenres
+                .Where(g => keys.Contains(g.Key))
+                .Select(g => new { g.Key, g.Id })
+                .ToListAsync(ct);
+            foreach (var g in found)
+                result[g.Key] = g.Id;
         }
 
-        return count;
+        return result;
     }
 
-    public static async Task<int> InsertOrIgnorePlexCountriesAsync(
+    public static async Task<Dictionary<string, int>> InsertOrIgnorePlexCountriesAsync(
         this IReaparrDbContext dbContext,
         IReadOnlyCollection<PlexCountry> entities,
         CancellationToken ct)
     {
-        var count = 0;
+        var result = new Dictionary<string, int>(entities.Count);
 
         foreach (var chunk in entities.Chunk(CHUNK_SIZE))
         {
+            var arguments = new List<object>(chunk.Length * 2);
+            var values = new List<string>(chunk.Length);
+            foreach (var country in chunk)
+            {
+                values.Add($"({{{arguments.Count}}}, {{{arguments.Count + 1}}})");
+                arguments.Add(country.Name);
+                arguments.Add(country.Key);
+            }
+
+            var sql = FormattableStringFactory.Create(
+                $"INSERT OR IGNORE INTO PlexCountries (Name, Key) VALUES {string.Join(", ", values)}",
+                arguments.ToArray()
+            );
             await ((DbContext)dbContext).ExecuteWithRetryAsync(async db =>
             {
-                var query = new StringBuilder();
-                foreach (var country in chunk)
-                {
-                    query.AppendLine(
-                        $"INSERT OR IGNORE INTO PlexCountries (Name, Key) VALUES ('{Escape(country.Name)}', '{Escape(country.Key)}');");
-                }
-
-                count += await db.Database.ExecuteSqlRawAsync(query.ToString(), ct);
-
+                await db.Database.ExecuteSqlInterpolatedAsync(sql, ct);
                 return true;
             }, cancellationToken: ct);
+
+            var keys = chunk.Select(c => c.Key).ToList();
+            var found = await dbContext.PlexCountries
+                .Where(c => keys.Contains(c.Key))
+                .Select(c => new { c.Key, c.Id })
+                .ToListAsync(ct);
+            foreach (var c in found)
+                result[c.Key] = c.Id;
         }
 
-        return count;
+        return result;
     }
-
-    private static string Escape(string value) => value.Replace("'", "''");
 }

--- a/src/Data.Contracts/packages.lock.json
+++ b/src/Data.Contracts/packages.lock.json
@@ -384,8 +384,8 @@
       },
       "Quartz": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "Ko3I49Yz1DqlxWi+fXqdG0FYJlHyGnra86m9RSlhPjIoXy7ip8FxyYJ70HcHc5s3xije0QvX81qG2dlxLEI7hQ==",
+        "resolved": "3.18.2",
+        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "2.1.1"
         }
@@ -498,7 +498,7 @@
       "Reaparr.Application.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },

--- a/src/Data/Data.csproj
+++ b/src/Data/Data.csproj
@@ -4,7 +4,7 @@
         <AssemblyName>Reaparr.Data</AssemblyName>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite" Version="0.5.2" />
+        <PackageReference Include="AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite" Version="0.6.0" />
         <PackageReference Include="Autofac" Version="9.1.0" />
         <PackageReference Include="CSharpier.MsBuild" Version="1.3.0">
             <PrivateAssets>all</PrivateAssets>

--- a/src/Data/packages.lock.json
+++ b/src/Data/packages.lock.json
@@ -660,8 +660,8 @@
       },
       "Quartz": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "Ko3I49Yz1DqlxWi+fXqdG0FYJlHyGnra86m9RSlhPjIoXy7ip8FxyYJ70HcHc5s3xije0QvX81qG2dlxLEI7hQ==",
+        "resolved": "3.18.2",
+        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "2.1.1"
         }
@@ -857,7 +857,7 @@
       "Reaparr.Application.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },

--- a/src/Data/packages.lock.json
+++ b/src/Data/packages.lock.json
@@ -4,12 +4,12 @@
     "net10.0": {
       "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": {
         "type": "Direct",
-        "requested": "[0.5.2, )",
-        "resolved": "0.5.2",
-        "contentHash": "ZzZScJNxyUuijtf0bl0rN6/MSoqeFa4f+4zbntZCDUy0zMBCs6bw4UoJbOtWwarn9xDgZiw6lanGmuKe0/YbkA==",
+        "requested": "[0.6.0, )",
+        "resolved": "0.6.0",
+        "contentHash": "gyRyO8EFn3u0AmnJCBBVDzjSKwfJUkrMIFWHL7ox/tp5buezNjWb7K6pyM33wkRRbSvhNqKSQhjoYYkSwPsBMw==",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.5.2",
-          "Microsoft.EntityFrameworkCore.Sqlite": "8.0.11"
+          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.6.0",
+          "Microsoft.EntityFrameworkCore.Sqlite": "10.0.8"
         }
       },
       "Autofac": {
@@ -123,10 +123,10 @@
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "6PBrhEH4S0t5T0DFZgmxPB7jXsEhkxaI6EY6Qt0r9NzOM8S0ukGcnROfPfgMkh7bpqZt/yhD4T7G2ObGBADhMA==",
+        "resolved": "0.6.0",
+        "contentHash": "hhhg6TeGEl5qczPD67xhJ9IYCpZ7PAd6CNiaA9vqK9a8y9tdXUp/Nkca19oTs55BxF8mmNSNUTjnO4T7lhKnvQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "8.0.11"
+          "Microsoft.EntityFrameworkCore": "10.0.8"
         }
       },
       "ByteSize": {

--- a/src/External/packages.lock.json
+++ b/src/External/packages.lock.json
@@ -203,8 +203,8 @@
       },
       "Quartz": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "Ko3I49Yz1DqlxWi+fXqdG0FYJlHyGnra86m9RSlhPjIoXy7ip8FxyYJ70HcHc5s3xije0QvX81qG2dlxLEI7hQ==",
+        "resolved": "3.18.2",
+        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "2.1.1"
         }
@@ -316,7 +316,7 @@
       "Reaparr.Application.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },

--- a/src/FileSystem/packages.lock.json
+++ b/src/FileSystem/packages.lock.json
@@ -395,8 +395,8 @@
       },
       "Quartz": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "Ko3I49Yz1DqlxWi+fXqdG0FYJlHyGnra86m9RSlhPjIoXy7ip8FxyYJ70HcHc5s3xije0QvX81qG2dlxLEI7hQ==",
+        "resolved": "3.18.2",
+        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "2.1.1"
         }
@@ -535,7 +535,7 @@
       "Reaparr.Application.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },

--- a/src/Identity.Contracts/packages.lock.json
+++ b/src/Identity.Contracts/packages.lock.json
@@ -486,8 +486,8 @@
       },
       "Quartz": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "Ko3I49Yz1DqlxWi+fXqdG0FYJlHyGnra86m9RSlhPjIoXy7ip8FxyYJ70HcHc5s3xije0QvX81qG2dlxLEI7hQ==",
+        "resolved": "3.18.2",
+        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "2.1.1"
         }
@@ -618,7 +618,7 @@
       "Reaparr.Application.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },

--- a/src/Identity/packages.lock.json
+++ b/src/Identity/packages.lock.json
@@ -688,8 +688,8 @@
       },
       "Quartz": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "Ko3I49Yz1DqlxWi+fXqdG0FYJlHyGnra86m9RSlhPjIoXy7ip8FxyYJ70HcHc5s3xije0QvX81qG2dlxLEI7hQ==",
+        "resolved": "3.18.2",
+        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "2.1.1"
         }
@@ -877,7 +877,7 @@
       "Reaparr.Application.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },

--- a/src/PlexApi.Contracts/PlexServer/GetServerStatus/GetServerStatusCommand.cs
+++ b/src/PlexApi.Contracts/PlexServer/GetServerStatus/GetServerStatusCommand.cs
@@ -15,4 +15,9 @@ public record GetServerStatusCommand : ICommand<Result<PlexServerStatus>>
     /// Progress action callback to notify of connection attempt progress.
     /// </summary>
     public required Action<HttpRequestRetryProgress>? ProgressAction { get; init; }
+
+    /// <summary>
+    /// Request timeout in seconds.
+    /// </summary>
+    public int Timeout { get; init; } = 10;
 }

--- a/src/PlexApi.Contracts/packages.lock.json
+++ b/src/PlexApi.Contracts/packages.lock.json
@@ -206,8 +206,8 @@
       },
       "Quartz": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "Ko3I49Yz1DqlxWi+fXqdG0FYJlHyGnra86m9RSlhPjIoXy7ip8FxyYJ70HcHc5s3xije0QvX81qG2dlxLEI7hQ==",
+        "resolved": "3.18.2",
+        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "2.1.1"
         }
@@ -298,7 +298,7 @@
       "Reaparr.Application.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },

--- a/src/PlexApi/PlexAPI/PlexAPIClient/PlexApiClient.cs
+++ b/src/PlexApi/PlexAPI/PlexAPIClient/PlexApiClient.cs
@@ -125,7 +125,7 @@ public class PlexApiClient : IPlexApiClient
         request.GetRetryProgressCallback()?.Invoke(
             new HttpRequestRetryProgress
             {
-                RetryAttemptIndex = 0,
+                RetryAttemptIndex = _options.RetryCount,
                 RetryAttemptCount = _options.RetryCount,
                 TimeToNextRetry = 0,
                 StatusCode = (int)statusCode,

--- a/src/PlexApi/PlexAPI/PlexAPIClient/PlexApiClient.cs
+++ b/src/PlexApi/PlexAPI/PlexAPIClient/PlexApiClient.cs
@@ -46,11 +46,17 @@ public class PlexApiClient : IPlexApiClient
         }
         catch (TaskCanceledException)
         {
-            return CreateErrorResponse(request, HttpStatusCode.RequestTimeout, "Request Timeout");
+            var statusCode = HttpStatusCode.RequestTimeout;
+            var reasonPhrase = "Request Timeout";
+            SendCompletedProgress(request, statusCode, reasonPhrase);
+            return CreateErrorResponse(request, statusCode, reasonPhrase);
         }
         catch (HttpRequestException)
         {
-            return CreateErrorResponse(request, HttpStatusCode.BadGateway, "Bad Gateway");
+            var statusCode = HttpStatusCode.BadGateway;
+            var reasonPhrase = "Bad Gateway";
+            SendCompletedProgress(request, statusCode, reasonPhrase);
+            return CreateErrorResponse(request, statusCode, reasonPhrase);
         }
 
         if (!response.IsSuccessStatusCode)
@@ -112,6 +118,24 @@ public class PlexApiClient : IPlexApiClient
                 DefaultJsonSerializerOptions.ConfigStandard
             )
             .ToStringContent();
+    }
+
+    private void SendCompletedProgress(HttpRequestMessage request, HttpStatusCode statusCode, string reasonPhrase)
+    {
+        request.GetRetryProgressCallback()?.Invoke(
+            new HttpRequestRetryProgress
+            {
+                RetryAttemptIndex = 0,
+                RetryAttemptCount = _options.RetryCount,
+                TimeToNextRetry = 0,
+                StatusCode = (int)statusCode,
+                ConnectionSuccessful = false,
+                Completed = true,
+                Message = reasonPhrase,
+                ErrorMessage = reasonPhrase,
+                RequestUri = request.RequestUri?.ToString() ?? "unknown",
+            }
+        );
     }
 
     private HttpResponseMessage CreateErrorResponse(

--- a/src/PlexApi/PlexServer/GetServerStatus/GetServerStatusCommandHandler.cs
+++ b/src/PlexApi/PlexServer/GetServerStatus/GetServerStatusCommandHandler.cs
@@ -27,7 +27,7 @@ public class GetServerStatusCommandHandler : ICommandHandler<GetServerStatusComm
             {
                 ConnectionUrl = connection.Url,
                 RetryProgressAction = command.ProgressAction,
-                Timeout = 10,
+                Timeout = command.Timeout,
                 RetryCount = 0,
             }
         );

--- a/src/PlexApi/packages.lock.json
+++ b/src/PlexApi/packages.lock.json
@@ -471,8 +471,8 @@
       },
       "Quartz": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "Ko3I49Yz1DqlxWi+fXqdG0FYJlHyGnra86m9RSlhPjIoXy7ip8FxyYJ70HcHc5s3xije0QvX81qG2dlxLEI7hQ==",
+        "resolved": "3.18.2",
+        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "2.1.1"
         }
@@ -590,14 +590,14 @@
       "Reaparr.Application.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },
       "Reaparr.BackgroundJobs.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },

--- a/src/PublicAPI/packages.lock.json
+++ b/src/PublicAPI/packages.lock.json
@@ -492,8 +492,8 @@
       },
       "Quartz": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "Ko3I49Yz1DqlxWi+fXqdG0FYJlHyGnra86m9RSlhPjIoXy7ip8FxyYJ70HcHc5s3xije0QvX81qG2dlxLEI7hQ==",
+        "resolved": "3.18.2",
+        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "2.1.1"
         }
@@ -624,7 +624,7 @@
       "Reaparr.Application.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },

--- a/src/SignalR/packages.lock.json
+++ b/src/SignalR/packages.lock.json
@@ -213,8 +213,8 @@
       },
       "Quartz": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "Ko3I49Yz1DqlxWi+fXqdG0FYJlHyGnra86m9RSlhPjIoXy7ip8FxyYJ70HcHc5s3xije0QvX81qG2dlxLEI7hQ==",
+        "resolved": "3.18.2",
+        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "2.1.1"
         }
@@ -305,7 +305,7 @@
       "Reaparr.Application.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },

--- a/tests/BaseTests/packages.lock.json
+++ b/tests/BaseTests/packages.lock.json
@@ -1232,37 +1232,37 @@
       },
       "Quartz": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "Ko3I49Yz1DqlxWi+fXqdG0FYJlHyGnra86m9RSlhPjIoXy7ip8FxyYJ70HcHc5s3xije0QvX81qG2dlxLEI7hQ==",
+        "resolved": "3.18.2",
+        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "2.1.1"
         }
       },
       "Quartz.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "SYPUS3eOwbYFv9mXwAqz6R0G5SHztRg0qG7GzQBsncSEW7y2vRvcMxnaYM5bGP1fF4SFBMdYAj25gGgQvD+tOA==",
+        "resolved": "3.18.2",
+        "contentHash": "+P0z/WUQZF/QrY5wB1wgvl9/VkiWqGR/K5bdtjW1qiFBraEoe/dqfNTxXQPnSZHnha1qmSBRoa5oA7kwHPsTqA==",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
           "Microsoft.Extensions.Options": "10.0.0",
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Quartz.Extensions.Hosting": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "6XgnbMBMsn5a7u2amkZVWKljVCQnO45SxDznpaRonXWolLNeX6Fx5t/73zigVshGLs3Q1A+NSv5z6oPTgv37sA==",
+        "resolved": "3.18.2",
+        "contentHash": "6uSMAm4FArjtVoxBjlkA+gHL1Eln2ngIOnRTrVrYxtSlM5PpLQd2aV+fc/OOwfwt+AyDm69HOAybEFqVvyyG2A==",
         "dependencies": {
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
-          "Quartz.Extensions.DependencyInjection": "3.17.0"
+          "Quartz.Extensions.DependencyInjection": "3.18.2"
         }
       },
       "Quartz.Serialization.SystemTextJson": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "QfqaugT/yokgUGhSrWHIpEGBUOhs0KJKZEd0WLIEoOj7m/eourC495pz1S/vq3I8LN81k6n8Pn6oky8qr3P2iw==",
+        "resolved": "3.18.2",
+        "contentHash": "FZAV4mUwnl4yNSa73ZuQNvBOZeyuPTUW4M8Mxa0XAFHUwgHGEYmqOVSgaztAET+a/fUGNBzj0eEPW2pZMQPYuA==",
         "dependencies": {
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Semver": {
@@ -1575,8 +1575,8 @@
           "Microsoft.AspNetCore.SpaServices.Extensions": "[10.0.9, )",
           "Microsoft.Extensions.Http.Polly": "[10.0.9, )",
           "Photino.NET": "[4.0.16, )",
-          "Quartz": "[3.17.0, )",
-          "Quartz.Extensions.Hosting": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
+          "Quartz.Extensions.Hosting": "[3.18.2, )",
           "Reaparr.Application": "[1.0.0, )",
           "Reaparr.BackgroundJobs": "[1.0.0, )",
           "Reaparr.Data": "[1.0.0, )",
@@ -1602,7 +1602,7 @@
           "FastEndpoints.Swagger": "[8.1.0, )",
           "Polly": "[8.6.5, )",
           "Polly.Core": "[8.6.6, )",
-          "Quartz.Serialization.SystemTextJson": "[3.17.0, )",
+          "Quartz.Serialization.SystemTextJson": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -1622,7 +1622,7 @@
       "Reaparr.Application.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },
@@ -1630,7 +1630,7 @@
         "type": "Project",
         "dependencies": {
           "Autofac.Extras.Quartz": "[11.0.0, )",
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -1642,7 +1642,7 @@
       "Reaparr.BackgroundJobs.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },

--- a/tests/BaseTests/packages.lock.json
+++ b/tests/BaseTests/packages.lock.json
@@ -115,19 +115,19 @@
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "6PBrhEH4S0t5T0DFZgmxPB7jXsEhkxaI6EY6Qt0r9NzOM8S0ukGcnROfPfgMkh7bpqZt/yhD4T7G2ObGBADhMA==",
+        "resolved": "0.6.0",
+        "contentHash": "hhhg6TeGEl5qczPD67xhJ9IYCpZ7PAd6CNiaA9vqK9a8y9tdXUp/Nkca19oTs55BxF8mmNSNUTjnO4T7lhKnvQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "8.0.11"
+          "Microsoft.EntityFrameworkCore": "10.0.8"
         }
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "ZzZScJNxyUuijtf0bl0rN6/MSoqeFa4f+4zbntZCDUy0zMBCs6bw4UoJbOtWwarn9xDgZiw6lanGmuKe0/YbkA==",
+        "resolved": "0.6.0",
+        "contentHash": "gyRyO8EFn3u0AmnJCBBVDzjSKwfJUkrMIFWHL7ox/tp5buezNjWb7K6pyM33wkRRbSvhNqKSQhjoYYkSwPsBMw==",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.5.2",
-          "Microsoft.EntityFrameworkCore.Sqlite": "8.0.11"
+          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.6.0",
+          "Microsoft.EntityFrameworkCore.Sqlite": "10.0.8"
         }
       },
       "Autofac.Extensions.DependencyInjection": {
@@ -1649,7 +1649,7 @@
       "Reaparr.Data": {
         "type": "Project",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.5.2, )",
+          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.6.0, )",
           "Autofac": "[9.1.0, )",
           "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.Data.Sqlite": "[10.0.9, )",

--- a/tests/IntegrationTests/IntegrationTests/packages.lock.json
+++ b/tests/IntegrationTests/IntegrationTests/packages.lock.json
@@ -29,19 +29,19 @@
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "6PBrhEH4S0t5T0DFZgmxPB7jXsEhkxaI6EY6Qt0r9NzOM8S0ukGcnROfPfgMkh7bpqZt/yhD4T7G2ObGBADhMA==",
+        "resolved": "0.6.0",
+        "contentHash": "hhhg6TeGEl5qczPD67xhJ9IYCpZ7PAd6CNiaA9vqK9a8y9tdXUp/Nkca19oTs55BxF8mmNSNUTjnO4T7lhKnvQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "8.0.11"
+          "Microsoft.EntityFrameworkCore": "10.0.8"
         }
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "ZzZScJNxyUuijtf0bl0rN6/MSoqeFa4f+4zbntZCDUy0zMBCs6bw4UoJbOtWwarn9xDgZiw6lanGmuKe0/YbkA==",
+        "resolved": "0.6.0",
+        "contentHash": "gyRyO8EFn3u0AmnJCBBVDzjSKwfJUkrMIFWHL7ox/tp5buezNjWb7K6pyM33wkRRbSvhNqKSQhjoYYkSwPsBMw==",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.5.2",
-          "Microsoft.EntityFrameworkCore.Sqlite": "8.0.11"
+          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.6.0",
+          "Microsoft.EntityFrameworkCore.Sqlite": "10.0.8"
         }
       },
       "Autofac": {
@@ -1662,7 +1662,7 @@
       "Reaparr.Data": {
         "type": "Project",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.5.2, )",
+          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.6.0, )",
           "Autofac": "[9.1.0, )",
           "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.Data.Sqlite": "[10.0.9, )",

--- a/tests/IntegrationTests/IntegrationTests/packages.lock.json
+++ b/tests/IntegrationTests/IntegrationTests/packages.lock.json
@@ -1210,37 +1210,37 @@
       },
       "Quartz": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "Ko3I49Yz1DqlxWi+fXqdG0FYJlHyGnra86m9RSlhPjIoXy7ip8FxyYJ70HcHc5s3xije0QvX81qG2dlxLEI7hQ==",
+        "resolved": "3.18.2",
+        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "2.1.1"
         }
       },
       "Quartz.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "SYPUS3eOwbYFv9mXwAqz6R0G5SHztRg0qG7GzQBsncSEW7y2vRvcMxnaYM5bGP1fF4SFBMdYAj25gGgQvD+tOA==",
+        "resolved": "3.18.2",
+        "contentHash": "+P0z/WUQZF/QrY5wB1wgvl9/VkiWqGR/K5bdtjW1qiFBraEoe/dqfNTxXQPnSZHnha1qmSBRoa5oA7kwHPsTqA==",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
           "Microsoft.Extensions.Options": "10.0.0",
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Quartz.Extensions.Hosting": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "6XgnbMBMsn5a7u2amkZVWKljVCQnO45SxDznpaRonXWolLNeX6Fx5t/73zigVshGLs3Q1A+NSv5z6oPTgv37sA==",
+        "resolved": "3.18.2",
+        "contentHash": "6uSMAm4FArjtVoxBjlkA+gHL1Eln2ngIOnRTrVrYxtSlM5PpLQd2aV+fc/OOwfwt+AyDm69HOAybEFqVvyyG2A==",
         "dependencies": {
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
-          "Quartz.Extensions.DependencyInjection": "3.17.0"
+          "Quartz.Extensions.DependencyInjection": "3.18.2"
         }
       },
       "Quartz.Serialization.SystemTextJson": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "QfqaugT/yokgUGhSrWHIpEGBUOhs0KJKZEd0WLIEoOj7m/eourC495pz1S/vq3I8LN81k6n8Pn6oky8qr3P2iw==",
+        "resolved": "3.18.2",
+        "contentHash": "FZAV4mUwnl4yNSa73ZuQNvBOZeyuPTUW4M8Mxa0XAFHUwgHGEYmqOVSgaztAET+a/fUGNBzj0eEPW2pZMQPYuA==",
         "dependencies": {
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Semver": {
@@ -1571,8 +1571,8 @@
           "Microsoft.AspNetCore.SpaServices.Extensions": "[10.0.9, )",
           "Microsoft.Extensions.Http.Polly": "[10.0.9, )",
           "Photino.NET": "[4.0.16, )",
-          "Quartz": "[3.17.0, )",
-          "Quartz.Extensions.Hosting": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
+          "Quartz.Extensions.Hosting": "[3.18.2, )",
           "Reaparr.Application": "[1.0.0, )",
           "Reaparr.BackgroundJobs": "[1.0.0, )",
           "Reaparr.Data": "[1.0.0, )",
@@ -1598,7 +1598,7 @@
           "FastEndpoints.Swagger": "[8.1.0, )",
           "Polly": "[8.6.5, )",
           "Polly.Core": "[8.6.6, )",
-          "Quartz.Serialization.SystemTextJson": "[3.17.0, )",
+          "Quartz.Serialization.SystemTextJson": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -1618,7 +1618,7 @@
       "Reaparr.Application.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },
@@ -1626,7 +1626,7 @@
         "type": "Project",
         "dependencies": {
           "Autofac.Extras.Quartz": "[11.0.0, )",
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -1638,7 +1638,7 @@
       "Reaparr.BackgroundJobs.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },

--- a/tests/UnitTests/AppHost.UnitTests/packages.lock.json
+++ b/tests/UnitTests/AppHost.UnitTests/packages.lock.json
@@ -1220,37 +1220,37 @@
       },
       "Quartz": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "Ko3I49Yz1DqlxWi+fXqdG0FYJlHyGnra86m9RSlhPjIoXy7ip8FxyYJ70HcHc5s3xije0QvX81qG2dlxLEI7hQ==",
+        "resolved": "3.18.2",
+        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "2.1.1"
         }
       },
       "Quartz.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "SYPUS3eOwbYFv9mXwAqz6R0G5SHztRg0qG7GzQBsncSEW7y2vRvcMxnaYM5bGP1fF4SFBMdYAj25gGgQvD+tOA==",
+        "resolved": "3.18.2",
+        "contentHash": "+P0z/WUQZF/QrY5wB1wgvl9/VkiWqGR/K5bdtjW1qiFBraEoe/dqfNTxXQPnSZHnha1qmSBRoa5oA7kwHPsTqA==",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
           "Microsoft.Extensions.Options": "10.0.0",
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Quartz.Extensions.Hosting": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "6XgnbMBMsn5a7u2amkZVWKljVCQnO45SxDznpaRonXWolLNeX6Fx5t/73zigVshGLs3Q1A+NSv5z6oPTgv37sA==",
+        "resolved": "3.18.2",
+        "contentHash": "6uSMAm4FArjtVoxBjlkA+gHL1Eln2ngIOnRTrVrYxtSlM5PpLQd2aV+fc/OOwfwt+AyDm69HOAybEFqVvyyG2A==",
         "dependencies": {
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
-          "Quartz.Extensions.DependencyInjection": "3.17.0"
+          "Quartz.Extensions.DependencyInjection": "3.18.2"
         }
       },
       "Quartz.Serialization.SystemTextJson": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "QfqaugT/yokgUGhSrWHIpEGBUOhs0KJKZEd0WLIEoOj7m/eourC495pz1S/vq3I8LN81k6n8Pn6oky8qr3P2iw==",
+        "resolved": "3.18.2",
+        "contentHash": "FZAV4mUwnl4yNSa73ZuQNvBOZeyuPTUW4M8Mxa0XAFHUwgHGEYmqOVSgaztAET+a/fUGNBzj0eEPW2pZMQPYuA==",
         "dependencies": {
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Semver": {
@@ -1602,8 +1602,8 @@
           "Microsoft.AspNetCore.SpaServices.Extensions": "[10.0.9, )",
           "Microsoft.Extensions.Http.Polly": "[10.0.9, )",
           "Photino.NET": "[4.0.16, )",
-          "Quartz": "[3.17.0, )",
-          "Quartz.Extensions.Hosting": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
+          "Quartz.Extensions.Hosting": "[3.18.2, )",
           "Reaparr.Application": "[1.0.0, )",
           "Reaparr.BackgroundJobs": "[1.0.0, )",
           "Reaparr.Data": "[1.0.0, )",
@@ -1629,7 +1629,7 @@
           "FastEndpoints.Swagger": "[8.1.0, )",
           "Polly": "[8.6.5, )",
           "Polly.Core": "[8.6.6, )",
-          "Quartz.Serialization.SystemTextJson": "[3.17.0, )",
+          "Quartz.Serialization.SystemTextJson": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -1649,7 +1649,7 @@
       "Reaparr.Application.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },
@@ -1657,7 +1657,7 @@
         "type": "Project",
         "dependencies": {
           "Autofac.Extras.Quartz": "[11.0.0, )",
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -1669,7 +1669,7 @@
       "Reaparr.BackgroundJobs.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },

--- a/tests/UnitTests/AppHost.UnitTests/packages.lock.json
+++ b/tests/UnitTests/AppHost.UnitTests/packages.lock.json
@@ -39,19 +39,19 @@
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "6PBrhEH4S0t5T0DFZgmxPB7jXsEhkxaI6EY6Qt0r9NzOM8S0ukGcnROfPfgMkh7bpqZt/yhD4T7G2ObGBADhMA==",
+        "resolved": "0.6.0",
+        "contentHash": "hhhg6TeGEl5qczPD67xhJ9IYCpZ7PAd6CNiaA9vqK9a8y9tdXUp/Nkca19oTs55BxF8mmNSNUTjnO4T7lhKnvQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "8.0.11"
+          "Microsoft.EntityFrameworkCore": "10.0.8"
         }
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "ZzZScJNxyUuijtf0bl0rN6/MSoqeFa4f+4zbntZCDUy0zMBCs6bw4UoJbOtWwarn9xDgZiw6lanGmuKe0/YbkA==",
+        "resolved": "0.6.0",
+        "contentHash": "gyRyO8EFn3u0AmnJCBBVDzjSKwfJUkrMIFWHL7ox/tp5buezNjWb7K6pyM33wkRRbSvhNqKSQhjoYYkSwPsBMw==",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.5.2",
-          "Microsoft.EntityFrameworkCore.Sqlite": "8.0.11"
+          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.6.0",
+          "Microsoft.EntityFrameworkCore.Sqlite": "10.0.8"
         }
       },
       "Autofac": {
@@ -1719,7 +1719,7 @@
       "Reaparr.Data": {
         "type": "Project",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.5.2, )",
+          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.6.0, )",
           "Autofac": "[9.1.0, )",
           "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.Data.Sqlite": "[10.0.9, )",

--- a/tests/UnitTests/Application.UnitTests/BackgroundServices/Listeners/DownloadJobListener.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/BackgroundServices/Listeners/DownloadJobListener.UnitTests.cs
@@ -21,8 +21,10 @@ public class DownloadJobListenerUnitTests : BaseUnitTest<DownloadJobListener>
 
         var jobDetail = Mock.Mock<IJobDetail>().Object;
         var jobContext = Mock.Mock<IJobExecutionContext>().Object;
-        var jobDataMap = new JobDataMap();
-        jobDataMap.Put(DownloadJob.DownloadTaskIdParameter, JsonSerializer.Serialize(downloadTask.ToKey()));
+        var jobDataMap = new JobDataMap
+        {
+            [DownloadJob.DownloadTaskIdParameter] = JsonSerializer.Serialize(downloadTask.ToKey()),
+        };
 
         Mock.Mock<IMoveDownloadFileQueue>()
             .Setup(x => x.CheckMoveDownloadFileJobQueue())
@@ -74,8 +76,10 @@ public class DownloadJobListenerUnitTests : BaseUnitTest<DownloadJobListener>
 
         var jobDetail = Mock.Mock<IJobDetail>().Object;
         var jobContext = Mock.Mock<IJobExecutionContext>().Object;
-        var jobDataMap = new JobDataMap();
-        jobDataMap.Put(DownloadJob.DownloadTaskIdParameter, JsonSerializer.Serialize(downloadTask.ToKey()));
+        var jobDataMap = new JobDataMap
+        {
+            [DownloadJob.DownloadTaskIdParameter] = JsonSerializer.Serialize(downloadTask.ToKey()),
+        };
 
         Mock.Mock<IMoveDownloadFileQueue>()
             .Setup(x => x.CheckMoveDownloadFileJobQueue())

--- a/tests/UnitTests/Application.UnitTests/PlexServerConnection/CheckAllConnectionsByServer/CheckAllConnectionsStatusByPlexServerCommand.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexServerConnection/CheckAllConnectionsByServer/CheckAllConnectionsStatusByPlexServerCommand.UnitTests.cs
@@ -137,6 +137,11 @@ public class CheckAllConnectionsStatusByPlexServerCommandUnitTests
         // Assert
         result.ShouldNotBeNull();
         result.IsSuccess.ShouldBeTrue();
+        Mock.Mock<ICommandExecutor>()
+            .Verify(
+                x => x.Send(It.Is<CheckConnectionStatusByIdCommand>(command => command.Timeout == 10), It.IsAny<CancellationToken>()),
+                Times.AtLeastOnce()
+            );
         Mock.Mock<IEventPublisher>()
             .Verify(
                 x => x.PublishAsync(It.IsAny<ServerOnlineStatusChangedNotification>(), It.IsAny<CancellationToken>()),

--- a/tests/UnitTests/Application.UnitTests/PlexServers/InspectPlexServer/InspectPlexServerJob.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexServers/InspectPlexServer/InspectPlexServerJob.UnitTests.cs
@@ -44,7 +44,7 @@ public class InspectPlexServerJobUnitTests : BaseUnitTest<InspectPlexServerJob>
         Mock.Mock<ICommandExecutor>()
             .Setup(x =>
                 x.Send(
-                    It.Is<CheckAllConnectionsStatusByPlexServerCommand>(command => command.Timeout == 3),
+                    It.Is<CheckAllConnectionsStatusByPlexServerCommand>(command => command.Timeout == 5),
                     It.IsAny<CancellationToken>()
                 )
             )
@@ -93,7 +93,7 @@ public class InspectPlexServerJobUnitTests : BaseUnitTest<InspectPlexServerJob>
         expectedLibraryIds.ShouldNotBeEmpty();
         Mock.Mock<ICommandExecutor>()
             .Verify(
-                x => x.Send(It.Is<CheckAllConnectionsStatusByPlexServerCommand>(command => command.Timeout == 3), It.IsAny<CancellationToken>()),
+                x => x.Send(It.Is<CheckAllConnectionsStatusByPlexServerCommand>(command => command.Timeout == 5), It.IsAny<CancellationToken>()),
                 Times.Exactly(plexServerIds.Count)
             );
         Mock.Mock<ICommandExecutor>()
@@ -149,7 +149,7 @@ public class InspectPlexServerJobUnitTests : BaseUnitTest<InspectPlexServerJob>
         Mock.Mock<ICommandExecutor>()
             .Setup(x =>
                 x.Send(
-                    It.Is<CheckAllConnectionsStatusByPlexServerCommand>(command => command.Timeout == 3),
+                    It.Is<CheckAllConnectionsStatusByPlexServerCommand>(command => command.Timeout == 5),
                     It.IsAny<CancellationToken>()
                 )
             )
@@ -193,7 +193,7 @@ public class InspectPlexServerJobUnitTests : BaseUnitTest<InspectPlexServerJob>
         // Assert
         Mock.Mock<ICommandExecutor>()
             .Verify(
-                x => x.Send(It.Is<CheckAllConnectionsStatusByPlexServerCommand>(command => command.Timeout == 3), It.IsAny<CancellationToken>()),
+                x => x.Send(It.Is<CheckAllConnectionsStatusByPlexServerCommand>(command => command.Timeout == 5), It.IsAny<CancellationToken>()),
                 Times.Exactly(plexServerIds.Count)
             );
         Mock.Mock<ICommandExecutor>()

--- a/tests/UnitTests/Application.UnitTests/PlexServers/InspectPlexServer/InspectPlexServerJob.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexServers/InspectPlexServer/InspectPlexServerJob.UnitTests.cs
@@ -44,7 +44,7 @@ public class InspectPlexServerJobUnitTests : BaseUnitTest<InspectPlexServerJob>
         Mock.Mock<ICommandExecutor>()
             .Setup(x =>
                 x.Send(
-                    It.IsAny<CheckAllConnectionsStatusByPlexServerCommand>(),
+                    It.Is<CheckAllConnectionsStatusByPlexServerCommand>(command => command.Timeout == 3),
                     It.IsAny<CancellationToken>()
                 )
             )
@@ -93,7 +93,7 @@ public class InspectPlexServerJobUnitTests : BaseUnitTest<InspectPlexServerJob>
         expectedLibraryIds.ShouldNotBeEmpty();
         Mock.Mock<ICommandExecutor>()
             .Verify(
-                x => x.Send(It.IsAny<CheckAllConnectionsStatusByPlexServerCommand>(), It.IsAny<CancellationToken>()),
+                x => x.Send(It.Is<CheckAllConnectionsStatusByPlexServerCommand>(command => command.Timeout == 3), It.IsAny<CancellationToken>()),
                 Times.Exactly(plexServerIds.Count)
             );
         Mock.Mock<ICommandExecutor>()
@@ -149,7 +149,7 @@ public class InspectPlexServerJobUnitTests : BaseUnitTest<InspectPlexServerJob>
         Mock.Mock<ICommandExecutor>()
             .Setup(x =>
                 x.Send(
-                    It.IsAny<CheckAllConnectionsStatusByPlexServerCommand>(),
+                    It.Is<CheckAllConnectionsStatusByPlexServerCommand>(command => command.Timeout == 3),
                     It.IsAny<CancellationToken>()
                 )
             )
@@ -193,7 +193,7 @@ public class InspectPlexServerJobUnitTests : BaseUnitTest<InspectPlexServerJob>
         // Assert
         Mock.Mock<ICommandExecutor>()
             .Verify(
-                x => x.Send(It.IsAny<CheckAllConnectionsStatusByPlexServerCommand>(), It.IsAny<CancellationToken>()),
+                x => x.Send(It.Is<CheckAllConnectionsStatusByPlexServerCommand>(command => command.Timeout == 3), It.IsAny<CancellationToken>()),
                 Times.Exactly(plexServerIds.Count)
             );
         Mock.Mock<ICommandExecutor>()

--- a/tests/UnitTests/Application.UnitTests/PlexServers/InspectPlexServer/InspectPlexServerJob.UnitTests.cs
+++ b/tests/UnitTests/Application.UnitTests/PlexServers/InspectPlexServer/InspectPlexServerJob.UnitTests.cs
@@ -1,0 +1,232 @@
+using System.Collections.Concurrent;
+using Reaparr.BackgroundJobs.Contracts;
+
+namespace Reaparr.Application.UnitTests;
+
+public class InspectPlexServerJobUnitTests : BaseUnitTest<InspectPlexServerJob>
+{
+    private IJobExecutionContext SetupJobContext(List<int> plexServerIds)
+    {
+        IDictionary<string, object> dict = new Dictionary<string, object>
+        {
+            { InspectPlexServerJob.PlexServerIdsParameter, JsonSerializer.Serialize(plexServerIds) },
+        };
+
+        Mock.Mock<IJobExecutionContext>().SetupGet(x => x.JobDetail.JobDataMap).Returns(new JobDataMap(dict));
+        Mock.Mock<IJobExecutionContext>().SetupGet(x => x.CancellationToken).Returns(CancellationToken);
+
+        return Mock.Create<IJobExecutionContext>();
+    }
+
+    [Test]
+    public async Task ShouldInspectServersInParallel_WhenMultipleServersAreQueued()
+    {
+        // Arrange
+        await SetupDatabase(90001, config =>
+        {
+            config.PlexServerCount = 2;
+            config.PlexMovieLibraryCount = 1;
+            config.PlexAccountCount = 1;
+        });
+
+        var dbContext = IDbContext;
+        var plexServerIds =
+            await dbContext.PlexServers.OrderBy(x => x.Id).Select(x => x.Id).ToListAsync(CancellationToken);
+        var expectedLibraryIds = await dbContext
+            .PlexLibraries.GroupBy(x => x.PlexServerId)
+            .Select(x => x.OrderBy(y => y.Id).Select(y => y.Id).ToList())
+            .ToListAsync(CancellationToken);
+        var startedServerIds = new ConcurrentDictionary<int, byte>();
+        var bothConnectionChecksStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseConnectionChecks = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var context = SetupJobContext(plexServerIds);
+
+        Mock.Mock<ICommandExecutor>()
+            .Setup(x =>
+                x.Send(
+                    It.IsAny<CheckAllConnectionsStatusByPlexServerCommand>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Returns<CheckAllConnectionsStatusByPlexServerCommand, CancellationToken>(async (command, _) =>
+            {
+                startedServerIds.TryAdd(command.PlexServerId, 0);
+                if (startedServerIds.Count == plexServerIds.Count)
+                    bothConnectionChecksStarted.SetResult();
+
+                await releaseConnectionChecks.Task.WaitAsync(TimeSpan.FromSeconds(5));
+                return Result.Ok(new List<PlexServerStatus>());
+            })
+            .Verifiable(Times.Exactly(plexServerIds.Count));
+
+        Mock.Mock<ICommandExecutor>()
+            .Setup(x => x.Send(It.IsAny<RefreshLibraryAccessCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Ok(new PlexLibraryAccessRefreshResponse { OfflineServers = [], Reports = [] }))
+            .Verifiable(Times.Exactly(plexServerIds.Count));
+
+        Mock.Mock<ICommandExecutor>()
+            .Setup(x => x.Send(It.IsAny<QueueLibrarySyncJobCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Ok())
+            .Verifiable(Times.Exactly(plexServerIds.Count));
+
+        Mock.Mock<INotificationHubService>()
+            .Setup(x =>
+                x.SendRefreshNotificationAsync(
+                    It.Is<List<RefreshDataType>>(types =>
+                        types.SequenceEqual(new[] { RefreshDataType.PlexAccount, RefreshDataType.PlexLibrary })
+                    ),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Returns(Task.CompletedTask)
+            .Verifiable(Times.Exactly(plexServerIds.Count));
+
+        // Act
+        var executeTask = Sut.Execute(context);
+        await bothConnectionChecksStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        executeTask.IsCompleted.ShouldBeFalse();
+        releaseConnectionChecks.SetResult();
+        await executeTask;
+
+        // Assert
+        startedServerIds.Keys.OrderBy(x => x).ShouldBe(plexServerIds);
+        expectedLibraryIds.ShouldNotBeEmpty();
+        Mock.Mock<ICommandExecutor>()
+            .Verify(
+                x => x.Send(It.IsAny<CheckAllConnectionsStatusByPlexServerCommand>(), It.IsAny<CancellationToken>()),
+                Times.Exactly(plexServerIds.Count)
+            );
+        Mock.Mock<ICommandExecutor>()
+            .Verify(
+                x => x.Send(It.IsAny<RefreshLibraryAccessCommand>(), It.IsAny<CancellationToken>()),
+                Times.Exactly(plexServerIds.Count)
+            );
+        foreach (var libraryIds in expectedLibraryIds)
+        {
+            Mock.Mock<ICommandExecutor>()
+                .Verify(
+                    x =>
+                        x.Send(
+                            It.Is<QueueLibrarySyncJobCommand>(command =>
+                                command.PlexLibraryIds.SequenceEqual(libraryIds)),
+                            It.IsAny<CancellationToken>()
+                        ),
+                    Times.Once
+                );
+        }
+
+        Mock.Mock<INotificationHubService>()
+            .Verify(
+                x =>
+                    x.SendRefreshNotificationAsync(
+                        It.Is<List<RefreshDataType>>(types =>
+                            types.SequenceEqual(new[] { RefreshDataType.PlexAccount, RefreshDataType.PlexLibrary })
+                        ),
+                        It.IsAny<CancellationToken>()
+                    ),
+                Times.Exactly(plexServerIds.Count)
+            );
+    }
+
+    [Test]
+    public async Task ShouldContinueInspectingRemainingServers_WhenOneServerConnectionCheckFails()
+    {
+        // Arrange
+        await SetupDatabase(90002, config =>
+        {
+            config.PlexServerCount = 2;
+            config.PlexMovieLibraryCount = 1;
+            config.PlexAccountCount = 1;
+        });
+
+        var dbContext = IDbContext;
+        var plexServerIds =
+            await dbContext.PlexServers.OrderBy(x => x.Id).Select(x => x.Id).ToListAsync(CancellationToken);
+        var failedServerId = plexServerIds.First();
+        var successfulServerId = plexServerIds.Last();
+        var context = SetupJobContext(plexServerIds);
+
+        Mock.Mock<ICommandExecutor>()
+            .Setup(x =>
+                x.Send(
+                    It.IsAny<CheckAllConnectionsStatusByPlexServerCommand>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Returns<CheckAllConnectionsStatusByPlexServerCommand, CancellationToken>((command, _) =>
+            {
+                if (command.PlexServerId == failedServerId)
+                    return Task.FromResult(Result.Fail<List<PlexServerStatus>>("failed"));
+
+                return Task.FromResult(Result.Ok(new List<PlexServerStatus>()));
+            })
+            .Verifiable(Times.Exactly(plexServerIds.Count));
+
+        Mock.Mock<ICommandExecutor>()
+            .Setup(x =>
+                x.Send(
+                    It.Is<RefreshLibraryAccessCommand>(command => command.PlexServerId == successfulServerId),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(Result.Ok(new PlexLibraryAccessRefreshResponse { OfflineServers = [], Reports = [] }))
+            .Verifiable(Times.Once);
+
+        Mock.Mock<ICommandExecutor>()
+            .Setup(x => x.Send(It.IsAny<QueueLibrarySyncJobCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Ok())
+            .Verifiable(Times.Once);
+
+        Mock.Mock<INotificationHubService>()
+            .Setup(x =>
+                x.SendRefreshNotificationAsync(
+                    It.IsAny<List<RefreshDataType>>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Returns(Task.CompletedTask)
+            .Verifiable(Times.Once);
+
+        // Act
+        await Sut.Execute(context);
+
+        // Assert
+        Mock.Mock<ICommandExecutor>()
+            .Verify(
+                x => x.Send(It.IsAny<CheckAllConnectionsStatusByPlexServerCommand>(), It.IsAny<CancellationToken>()),
+                Times.Exactly(plexServerIds.Count)
+            );
+        Mock.Mock<ICommandExecutor>()
+            .Verify(
+                x =>
+                    x.Send(
+                        It.Is<RefreshLibraryAccessCommand>(command => command.PlexServerId == successfulServerId),
+                        It.IsAny<CancellationToken>()
+                    ),
+                Times.Once
+            );
+        Mock.Mock<ICommandExecutor>()
+            .Verify(
+                x =>
+                    x.Send(
+                        It.Is<RefreshLibraryAccessCommand>(command => command.PlexServerId == failedServerId),
+                        It.IsAny<CancellationToken>()
+                    ),
+                Times.Never
+            );
+        Mock.Mock<ICommandExecutor>()
+            .Verify(
+                x => x.Send(It.IsAny<QueueLibrarySyncJobCommand>(), It.IsAny<CancellationToken>()),
+                Times.Once
+            );
+        Mock.Mock<INotificationHubService>()
+            .Verify(
+                x =>
+                    x.SendRefreshNotificationAsync(
+                        It.IsAny<List<RefreshDataType>>(),
+                        It.IsAny<CancellationToken>()
+                    ),
+                Times.Once
+            );
+    }
+}

--- a/tests/UnitTests/Application.UnitTests/packages.lock.json
+++ b/tests/UnitTests/Application.UnitTests/packages.lock.json
@@ -29,19 +29,19 @@
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "6PBrhEH4S0t5T0DFZgmxPB7jXsEhkxaI6EY6Qt0r9NzOM8S0ukGcnROfPfgMkh7bpqZt/yhD4T7G2ObGBADhMA==",
+        "resolved": "0.6.0",
+        "contentHash": "hhhg6TeGEl5qczPD67xhJ9IYCpZ7PAd6CNiaA9vqK9a8y9tdXUp/Nkca19oTs55BxF8mmNSNUTjnO4T7lhKnvQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "8.0.11"
+          "Microsoft.EntityFrameworkCore": "10.0.8"
         }
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "ZzZScJNxyUuijtf0bl0rN6/MSoqeFa4f+4zbntZCDUy0zMBCs6bw4UoJbOtWwarn9xDgZiw6lanGmuKe0/YbkA==",
+        "resolved": "0.6.0",
+        "contentHash": "gyRyO8EFn3u0AmnJCBBVDzjSKwfJUkrMIFWHL7ox/tp5buezNjWb7K6pyM33wkRRbSvhNqKSQhjoYYkSwPsBMw==",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.5.2",
-          "Microsoft.EntityFrameworkCore.Sqlite": "8.0.11"
+          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.6.0",
+          "Microsoft.EntityFrameworkCore.Sqlite": "10.0.8"
         }
       },
       "Autofac": {
@@ -1662,7 +1662,7 @@
       "Reaparr.Data": {
         "type": "Project",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.5.2, )",
+          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.6.0, )",
           "Autofac": "[9.1.0, )",
           "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.Data.Sqlite": "[10.0.9, )",

--- a/tests/UnitTests/Application.UnitTests/packages.lock.json
+++ b/tests/UnitTests/Application.UnitTests/packages.lock.json
@@ -1210,37 +1210,37 @@
       },
       "Quartz": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "Ko3I49Yz1DqlxWi+fXqdG0FYJlHyGnra86m9RSlhPjIoXy7ip8FxyYJ70HcHc5s3xije0QvX81qG2dlxLEI7hQ==",
+        "resolved": "3.18.2",
+        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "2.1.1"
         }
       },
       "Quartz.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "SYPUS3eOwbYFv9mXwAqz6R0G5SHztRg0qG7GzQBsncSEW7y2vRvcMxnaYM5bGP1fF4SFBMdYAj25gGgQvD+tOA==",
+        "resolved": "3.18.2",
+        "contentHash": "+P0z/WUQZF/QrY5wB1wgvl9/VkiWqGR/K5bdtjW1qiFBraEoe/dqfNTxXQPnSZHnha1qmSBRoa5oA7kwHPsTqA==",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
           "Microsoft.Extensions.Options": "10.0.0",
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Quartz.Extensions.Hosting": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "6XgnbMBMsn5a7u2amkZVWKljVCQnO45SxDznpaRonXWolLNeX6Fx5t/73zigVshGLs3Q1A+NSv5z6oPTgv37sA==",
+        "resolved": "3.18.2",
+        "contentHash": "6uSMAm4FArjtVoxBjlkA+gHL1Eln2ngIOnRTrVrYxtSlM5PpLQd2aV+fc/OOwfwt+AyDm69HOAybEFqVvyyG2A==",
         "dependencies": {
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
-          "Quartz.Extensions.DependencyInjection": "3.17.0"
+          "Quartz.Extensions.DependencyInjection": "3.18.2"
         }
       },
       "Quartz.Serialization.SystemTextJson": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "QfqaugT/yokgUGhSrWHIpEGBUOhs0KJKZEd0WLIEoOj7m/eourC495pz1S/vq3I8LN81k6n8Pn6oky8qr3P2iw==",
+        "resolved": "3.18.2",
+        "contentHash": "FZAV4mUwnl4yNSa73ZuQNvBOZeyuPTUW4M8Mxa0XAFHUwgHGEYmqOVSgaztAET+a/fUGNBzj0eEPW2pZMQPYuA==",
         "dependencies": {
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Semver": {
@@ -1571,8 +1571,8 @@
           "Microsoft.AspNetCore.SpaServices.Extensions": "[10.0.9, )",
           "Microsoft.Extensions.Http.Polly": "[10.0.9, )",
           "Photino.NET": "[4.0.16, )",
-          "Quartz": "[3.17.0, )",
-          "Quartz.Extensions.Hosting": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
+          "Quartz.Extensions.Hosting": "[3.18.2, )",
           "Reaparr.Application": "[1.0.0, )",
           "Reaparr.BackgroundJobs": "[1.0.0, )",
           "Reaparr.Data": "[1.0.0, )",
@@ -1598,7 +1598,7 @@
           "FastEndpoints.Swagger": "[8.1.0, )",
           "Polly": "[8.6.5, )",
           "Polly.Core": "[8.6.6, )",
-          "Quartz.Serialization.SystemTextJson": "[3.17.0, )",
+          "Quartz.Serialization.SystemTextJson": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -1618,7 +1618,7 @@
       "Reaparr.Application.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },
@@ -1626,7 +1626,7 @@
         "type": "Project",
         "dependencies": {
           "Autofac.Extras.Quartz": "[11.0.0, )",
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -1638,7 +1638,7 @@
       "Reaparr.BackgroundJobs.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },

--- a/tests/UnitTests/BackgroundJobs.UnitTests/packages.lock.json
+++ b/tests/UnitTests/BackgroundJobs.UnitTests/packages.lock.json
@@ -29,19 +29,19 @@
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "6PBrhEH4S0t5T0DFZgmxPB7jXsEhkxaI6EY6Qt0r9NzOM8S0ukGcnROfPfgMkh7bpqZt/yhD4T7G2ObGBADhMA==",
+        "resolved": "0.6.0",
+        "contentHash": "hhhg6TeGEl5qczPD67xhJ9IYCpZ7PAd6CNiaA9vqK9a8y9tdXUp/Nkca19oTs55BxF8mmNSNUTjnO4T7lhKnvQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "8.0.11"
+          "Microsoft.EntityFrameworkCore": "10.0.8"
         }
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "ZzZScJNxyUuijtf0bl0rN6/MSoqeFa4f+4zbntZCDUy0zMBCs6bw4UoJbOtWwarn9xDgZiw6lanGmuKe0/YbkA==",
+        "resolved": "0.6.0",
+        "contentHash": "gyRyO8EFn3u0AmnJCBBVDzjSKwfJUkrMIFWHL7ox/tp5buezNjWb7K6pyM33wkRRbSvhNqKSQhjoYYkSwPsBMw==",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.5.2",
-          "Microsoft.EntityFrameworkCore.Sqlite": "8.0.11"
+          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.6.0",
+          "Microsoft.EntityFrameworkCore.Sqlite": "10.0.8"
         }
       },
       "Autofac": {
@@ -1662,7 +1662,7 @@
       "Reaparr.Data": {
         "type": "Project",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.5.2, )",
+          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.6.0, )",
           "Autofac": "[9.1.0, )",
           "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.Data.Sqlite": "[10.0.9, )",

--- a/tests/UnitTests/BackgroundJobs.UnitTests/packages.lock.json
+++ b/tests/UnitTests/BackgroundJobs.UnitTests/packages.lock.json
@@ -1210,37 +1210,37 @@
       },
       "Quartz": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "Ko3I49Yz1DqlxWi+fXqdG0FYJlHyGnra86m9RSlhPjIoXy7ip8FxyYJ70HcHc5s3xije0QvX81qG2dlxLEI7hQ==",
+        "resolved": "3.18.2",
+        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "2.1.1"
         }
       },
       "Quartz.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "SYPUS3eOwbYFv9mXwAqz6R0G5SHztRg0qG7GzQBsncSEW7y2vRvcMxnaYM5bGP1fF4SFBMdYAj25gGgQvD+tOA==",
+        "resolved": "3.18.2",
+        "contentHash": "+P0z/WUQZF/QrY5wB1wgvl9/VkiWqGR/K5bdtjW1qiFBraEoe/dqfNTxXQPnSZHnha1qmSBRoa5oA7kwHPsTqA==",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
           "Microsoft.Extensions.Options": "10.0.0",
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Quartz.Extensions.Hosting": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "6XgnbMBMsn5a7u2amkZVWKljVCQnO45SxDznpaRonXWolLNeX6Fx5t/73zigVshGLs3Q1A+NSv5z6oPTgv37sA==",
+        "resolved": "3.18.2",
+        "contentHash": "6uSMAm4FArjtVoxBjlkA+gHL1Eln2ngIOnRTrVrYxtSlM5PpLQd2aV+fc/OOwfwt+AyDm69HOAybEFqVvyyG2A==",
         "dependencies": {
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
-          "Quartz.Extensions.DependencyInjection": "3.17.0"
+          "Quartz.Extensions.DependencyInjection": "3.18.2"
         }
       },
       "Quartz.Serialization.SystemTextJson": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "QfqaugT/yokgUGhSrWHIpEGBUOhs0KJKZEd0WLIEoOj7m/eourC495pz1S/vq3I8LN81k6n8Pn6oky8qr3P2iw==",
+        "resolved": "3.18.2",
+        "contentHash": "FZAV4mUwnl4yNSa73ZuQNvBOZeyuPTUW4M8Mxa0XAFHUwgHGEYmqOVSgaztAET+a/fUGNBzj0eEPW2pZMQPYuA==",
         "dependencies": {
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Semver": {
@@ -1571,8 +1571,8 @@
           "Microsoft.AspNetCore.SpaServices.Extensions": "[10.0.9, )",
           "Microsoft.Extensions.Http.Polly": "[10.0.9, )",
           "Photino.NET": "[4.0.16, )",
-          "Quartz": "[3.17.0, )",
-          "Quartz.Extensions.Hosting": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
+          "Quartz.Extensions.Hosting": "[3.18.2, )",
           "Reaparr.Application": "[1.0.0, )",
           "Reaparr.BackgroundJobs": "[1.0.0, )",
           "Reaparr.Data": "[1.0.0, )",
@@ -1598,7 +1598,7 @@
           "FastEndpoints.Swagger": "[8.1.0, )",
           "Polly": "[8.6.5, )",
           "Polly.Core": "[8.6.6, )",
-          "Quartz.Serialization.SystemTextJson": "[3.17.0, )",
+          "Quartz.Serialization.SystemTextJson": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -1618,7 +1618,7 @@
       "Reaparr.Application.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },
@@ -1626,7 +1626,7 @@
         "type": "Project",
         "dependencies": {
           "Autofac.Extras.Quartz": "[11.0.0, )",
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -1638,7 +1638,7 @@
       "Reaparr.BackgroundJobs.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },

--- a/tests/UnitTests/BaseTests.UnitTests/packages.lock.json
+++ b/tests/UnitTests/BaseTests.UnitTests/packages.lock.json
@@ -1220,37 +1220,37 @@
       },
       "Quartz": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "Ko3I49Yz1DqlxWi+fXqdG0FYJlHyGnra86m9RSlhPjIoXy7ip8FxyYJ70HcHc5s3xije0QvX81qG2dlxLEI7hQ==",
+        "resolved": "3.18.2",
+        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "2.1.1"
         }
       },
       "Quartz.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "SYPUS3eOwbYFv9mXwAqz6R0G5SHztRg0qG7GzQBsncSEW7y2vRvcMxnaYM5bGP1fF4SFBMdYAj25gGgQvD+tOA==",
+        "resolved": "3.18.2",
+        "contentHash": "+P0z/WUQZF/QrY5wB1wgvl9/VkiWqGR/K5bdtjW1qiFBraEoe/dqfNTxXQPnSZHnha1qmSBRoa5oA7kwHPsTqA==",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
           "Microsoft.Extensions.Options": "10.0.0",
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Quartz.Extensions.Hosting": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "6XgnbMBMsn5a7u2amkZVWKljVCQnO45SxDznpaRonXWolLNeX6Fx5t/73zigVshGLs3Q1A+NSv5z6oPTgv37sA==",
+        "resolved": "3.18.2",
+        "contentHash": "6uSMAm4FArjtVoxBjlkA+gHL1Eln2ngIOnRTrVrYxtSlM5PpLQd2aV+fc/OOwfwt+AyDm69HOAybEFqVvyyG2A==",
         "dependencies": {
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
-          "Quartz.Extensions.DependencyInjection": "3.17.0"
+          "Quartz.Extensions.DependencyInjection": "3.18.2"
         }
       },
       "Quartz.Serialization.SystemTextJson": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "QfqaugT/yokgUGhSrWHIpEGBUOhs0KJKZEd0WLIEoOj7m/eourC495pz1S/vq3I8LN81k6n8Pn6oky8qr3P2iw==",
+        "resolved": "3.18.2",
+        "contentHash": "FZAV4mUwnl4yNSa73ZuQNvBOZeyuPTUW4M8Mxa0XAFHUwgHGEYmqOVSgaztAET+a/fUGNBzj0eEPW2pZMQPYuA==",
         "dependencies": {
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Semver": {
@@ -1572,8 +1572,8 @@
           "Microsoft.AspNetCore.SpaServices.Extensions": "[10.0.9, )",
           "Microsoft.Extensions.Http.Polly": "[10.0.9, )",
           "Photino.NET": "[4.0.16, )",
-          "Quartz": "[3.17.0, )",
-          "Quartz.Extensions.Hosting": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
+          "Quartz.Extensions.Hosting": "[3.18.2, )",
           "Reaparr.Application": "[1.0.0, )",
           "Reaparr.BackgroundJobs": "[1.0.0, )",
           "Reaparr.Data": "[1.0.0, )",
@@ -1599,7 +1599,7 @@
           "FastEndpoints.Swagger": "[8.1.0, )",
           "Polly": "[8.6.5, )",
           "Polly.Core": "[8.6.6, )",
-          "Quartz.Serialization.SystemTextJson": "[3.17.0, )",
+          "Quartz.Serialization.SystemTextJson": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -1619,7 +1619,7 @@
       "Reaparr.Application.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },
@@ -1627,7 +1627,7 @@
         "type": "Project",
         "dependencies": {
           "Autofac.Extras.Quartz": "[11.0.0, )",
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -1639,7 +1639,7 @@
       "Reaparr.BackgroundJobs.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },

--- a/tests/UnitTests/BaseTests.UnitTests/packages.lock.json
+++ b/tests/UnitTests/BaseTests.UnitTests/packages.lock.json
@@ -39,19 +39,19 @@
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "6PBrhEH4S0t5T0DFZgmxPB7jXsEhkxaI6EY6Qt0r9NzOM8S0ukGcnROfPfgMkh7bpqZt/yhD4T7G2ObGBADhMA==",
+        "resolved": "0.6.0",
+        "contentHash": "hhhg6TeGEl5qczPD67xhJ9IYCpZ7PAd6CNiaA9vqK9a8y9tdXUp/Nkca19oTs55BxF8mmNSNUTjnO4T7lhKnvQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "8.0.11"
+          "Microsoft.EntityFrameworkCore": "10.0.8"
         }
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "ZzZScJNxyUuijtf0bl0rN6/MSoqeFa4f+4zbntZCDUy0zMBCs6bw4UoJbOtWwarn9xDgZiw6lanGmuKe0/YbkA==",
+        "resolved": "0.6.0",
+        "contentHash": "gyRyO8EFn3u0AmnJCBBVDzjSKwfJUkrMIFWHL7ox/tp5buezNjWb7K6pyM33wkRRbSvhNqKSQhjoYYkSwPsBMw==",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.5.2",
-          "Microsoft.EntityFrameworkCore.Sqlite": "8.0.11"
+          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.6.0",
+          "Microsoft.EntityFrameworkCore.Sqlite": "10.0.8"
         }
       },
       "Autofac": {
@@ -1663,7 +1663,7 @@
       "Reaparr.Data": {
         "type": "Project",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.5.2, )",
+          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.6.0, )",
           "Autofac": "[9.1.0, )",
           "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.Data.Sqlite": "[10.0.9, )",

--- a/tests/UnitTests/Build.UnitTests/packages.lock.json
+++ b/tests/UnitTests/Build.UnitTests/packages.lock.json
@@ -1220,37 +1220,37 @@
       },
       "Quartz": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "Ko3I49Yz1DqlxWi+fXqdG0FYJlHyGnra86m9RSlhPjIoXy7ip8FxyYJ70HcHc5s3xije0QvX81qG2dlxLEI7hQ==",
+        "resolved": "3.18.2",
+        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "2.1.1"
         }
       },
       "Quartz.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "SYPUS3eOwbYFv9mXwAqz6R0G5SHztRg0qG7GzQBsncSEW7y2vRvcMxnaYM5bGP1fF4SFBMdYAj25gGgQvD+tOA==",
+        "resolved": "3.18.2",
+        "contentHash": "+P0z/WUQZF/QrY5wB1wgvl9/VkiWqGR/K5bdtjW1qiFBraEoe/dqfNTxXQPnSZHnha1qmSBRoa5oA7kwHPsTqA==",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
           "Microsoft.Extensions.Options": "10.0.0",
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Quartz.Extensions.Hosting": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "6XgnbMBMsn5a7u2amkZVWKljVCQnO45SxDznpaRonXWolLNeX6Fx5t/73zigVshGLs3Q1A+NSv5z6oPTgv37sA==",
+        "resolved": "3.18.2",
+        "contentHash": "6uSMAm4FArjtVoxBjlkA+gHL1Eln2ngIOnRTrVrYxtSlM5PpLQd2aV+fc/OOwfwt+AyDm69HOAybEFqVvyyG2A==",
         "dependencies": {
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
-          "Quartz.Extensions.DependencyInjection": "3.17.0"
+          "Quartz.Extensions.DependencyInjection": "3.18.2"
         }
       },
       "Quartz.Serialization.SystemTextJson": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "QfqaugT/yokgUGhSrWHIpEGBUOhs0KJKZEd0WLIEoOj7m/eourC495pz1S/vq3I8LN81k6n8Pn6oky8qr3P2iw==",
+        "resolved": "3.18.2",
+        "contentHash": "FZAV4mUwnl4yNSa73ZuQNvBOZeyuPTUW4M8Mxa0XAFHUwgHGEYmqOVSgaztAET+a/fUGNBzj0eEPW2pZMQPYuA==",
         "dependencies": {
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Semver": {
@@ -1602,8 +1602,8 @@
           "Microsoft.AspNetCore.SpaServices.Extensions": "[10.0.9, )",
           "Microsoft.Extensions.Http.Polly": "[10.0.9, )",
           "Photino.NET": "[4.0.16, )",
-          "Quartz": "[3.17.0, )",
-          "Quartz.Extensions.Hosting": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
+          "Quartz.Extensions.Hosting": "[3.18.2, )",
           "Reaparr.Application": "[1.0.0, )",
           "Reaparr.BackgroundJobs": "[1.0.0, )",
           "Reaparr.Data": "[1.0.0, )",
@@ -1629,7 +1629,7 @@
           "FastEndpoints.Swagger": "[8.1.0, )",
           "Polly": "[8.6.5, )",
           "Polly.Core": "[8.6.6, )",
-          "Quartz.Serialization.SystemTextJson": "[3.17.0, )",
+          "Quartz.Serialization.SystemTextJson": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -1649,7 +1649,7 @@
       "Reaparr.Application.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },
@@ -1657,7 +1657,7 @@
         "type": "Project",
         "dependencies": {
           "Autofac.Extras.Quartz": "[11.0.0, )",
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -1669,7 +1669,7 @@
       "Reaparr.BackgroundJobs.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },

--- a/tests/UnitTests/Build.UnitTests/packages.lock.json
+++ b/tests/UnitTests/Build.UnitTests/packages.lock.json
@@ -39,19 +39,19 @@
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "6PBrhEH4S0t5T0DFZgmxPB7jXsEhkxaI6EY6Qt0r9NzOM8S0ukGcnROfPfgMkh7bpqZt/yhD4T7G2ObGBADhMA==",
+        "resolved": "0.6.0",
+        "contentHash": "hhhg6TeGEl5qczPD67xhJ9IYCpZ7PAd6CNiaA9vqK9a8y9tdXUp/Nkca19oTs55BxF8mmNSNUTjnO4T7lhKnvQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "8.0.11"
+          "Microsoft.EntityFrameworkCore": "10.0.8"
         }
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "ZzZScJNxyUuijtf0bl0rN6/MSoqeFa4f+4zbntZCDUy0zMBCs6bw4UoJbOtWwarn9xDgZiw6lanGmuKe0/YbkA==",
+        "resolved": "0.6.0",
+        "contentHash": "gyRyO8EFn3u0AmnJCBBVDzjSKwfJUkrMIFWHL7ox/tp5buezNjWb7K6pyM33wkRRbSvhNqKSQhjoYYkSwPsBMw==",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.5.2",
-          "Microsoft.EntityFrameworkCore.Sqlite": "8.0.11"
+          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.6.0",
+          "Microsoft.EntityFrameworkCore.Sqlite": "10.0.8"
         }
       },
       "Autofac": {
@@ -1719,7 +1719,7 @@
       "Reaparr.Data": {
         "type": "Project",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.5.2, )",
+          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.6.0, )",
           "Autofac": "[9.1.0, )",
           "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.Data.Sqlite": "[10.0.9, )",

--- a/tests/UnitTests/Data.UnitTests/packages.lock.json
+++ b/tests/UnitTests/Data.UnitTests/packages.lock.json
@@ -29,19 +29,19 @@
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "6PBrhEH4S0t5T0DFZgmxPB7jXsEhkxaI6EY6Qt0r9NzOM8S0ukGcnROfPfgMkh7bpqZt/yhD4T7G2ObGBADhMA==",
+        "resolved": "0.6.0",
+        "contentHash": "hhhg6TeGEl5qczPD67xhJ9IYCpZ7PAd6CNiaA9vqK9a8y9tdXUp/Nkca19oTs55BxF8mmNSNUTjnO4T7lhKnvQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "8.0.11"
+          "Microsoft.EntityFrameworkCore": "10.0.8"
         }
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "ZzZScJNxyUuijtf0bl0rN6/MSoqeFa4f+4zbntZCDUy0zMBCs6bw4UoJbOtWwarn9xDgZiw6lanGmuKe0/YbkA==",
+        "resolved": "0.6.0",
+        "contentHash": "gyRyO8EFn3u0AmnJCBBVDzjSKwfJUkrMIFWHL7ox/tp5buezNjWb7K6pyM33wkRRbSvhNqKSQhjoYYkSwPsBMw==",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.5.2",
-          "Microsoft.EntityFrameworkCore.Sqlite": "8.0.11"
+          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.6.0",
+          "Microsoft.EntityFrameworkCore.Sqlite": "10.0.8"
         }
       },
       "Autofac": {
@@ -1662,7 +1662,7 @@
       "Reaparr.Data": {
         "type": "Project",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.5.2, )",
+          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.6.0, )",
           "Autofac": "[9.1.0, )",
           "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.Data.Sqlite": "[10.0.9, )",

--- a/tests/UnitTests/Data.UnitTests/packages.lock.json
+++ b/tests/UnitTests/Data.UnitTests/packages.lock.json
@@ -1210,37 +1210,37 @@
       },
       "Quartz": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "Ko3I49Yz1DqlxWi+fXqdG0FYJlHyGnra86m9RSlhPjIoXy7ip8FxyYJ70HcHc5s3xije0QvX81qG2dlxLEI7hQ==",
+        "resolved": "3.18.2",
+        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "2.1.1"
         }
       },
       "Quartz.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "SYPUS3eOwbYFv9mXwAqz6R0G5SHztRg0qG7GzQBsncSEW7y2vRvcMxnaYM5bGP1fF4SFBMdYAj25gGgQvD+tOA==",
+        "resolved": "3.18.2",
+        "contentHash": "+P0z/WUQZF/QrY5wB1wgvl9/VkiWqGR/K5bdtjW1qiFBraEoe/dqfNTxXQPnSZHnha1qmSBRoa5oA7kwHPsTqA==",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
           "Microsoft.Extensions.Options": "10.0.0",
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Quartz.Extensions.Hosting": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "6XgnbMBMsn5a7u2amkZVWKljVCQnO45SxDznpaRonXWolLNeX6Fx5t/73zigVshGLs3Q1A+NSv5z6oPTgv37sA==",
+        "resolved": "3.18.2",
+        "contentHash": "6uSMAm4FArjtVoxBjlkA+gHL1Eln2ngIOnRTrVrYxtSlM5PpLQd2aV+fc/OOwfwt+AyDm69HOAybEFqVvyyG2A==",
         "dependencies": {
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
-          "Quartz.Extensions.DependencyInjection": "3.17.0"
+          "Quartz.Extensions.DependencyInjection": "3.18.2"
         }
       },
       "Quartz.Serialization.SystemTextJson": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "QfqaugT/yokgUGhSrWHIpEGBUOhs0KJKZEd0WLIEoOj7m/eourC495pz1S/vq3I8LN81k6n8Pn6oky8qr3P2iw==",
+        "resolved": "3.18.2",
+        "contentHash": "FZAV4mUwnl4yNSa73ZuQNvBOZeyuPTUW4M8Mxa0XAFHUwgHGEYmqOVSgaztAET+a/fUGNBzj0eEPW2pZMQPYuA==",
         "dependencies": {
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Semver": {
@@ -1571,8 +1571,8 @@
           "Microsoft.AspNetCore.SpaServices.Extensions": "[10.0.9, )",
           "Microsoft.Extensions.Http.Polly": "[10.0.9, )",
           "Photino.NET": "[4.0.16, )",
-          "Quartz": "[3.17.0, )",
-          "Quartz.Extensions.Hosting": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
+          "Quartz.Extensions.Hosting": "[3.18.2, )",
           "Reaparr.Application": "[1.0.0, )",
           "Reaparr.BackgroundJobs": "[1.0.0, )",
           "Reaparr.Data": "[1.0.0, )",
@@ -1598,7 +1598,7 @@
           "FastEndpoints.Swagger": "[8.1.0, )",
           "Polly": "[8.6.5, )",
           "Polly.Core": "[8.6.6, )",
-          "Quartz.Serialization.SystemTextJson": "[3.17.0, )",
+          "Quartz.Serialization.SystemTextJson": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -1618,7 +1618,7 @@
       "Reaparr.Application.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },
@@ -1626,7 +1626,7 @@
         "type": "Project",
         "dependencies": {
           "Autofac.Extras.Quartz": "[11.0.0, )",
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -1638,7 +1638,7 @@
       "Reaparr.BackgroundJobs.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },

--- a/tests/UnitTests/Domain.UnitTests/packages.lock.json
+++ b/tests/UnitTests/Domain.UnitTests/packages.lock.json
@@ -29,19 +29,19 @@
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "6PBrhEH4S0t5T0DFZgmxPB7jXsEhkxaI6EY6Qt0r9NzOM8S0ukGcnROfPfgMkh7bpqZt/yhD4T7G2ObGBADhMA==",
+        "resolved": "0.6.0",
+        "contentHash": "hhhg6TeGEl5qczPD67xhJ9IYCpZ7PAd6CNiaA9vqK9a8y9tdXUp/Nkca19oTs55BxF8mmNSNUTjnO4T7lhKnvQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "8.0.11"
+          "Microsoft.EntityFrameworkCore": "10.0.8"
         }
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "ZzZScJNxyUuijtf0bl0rN6/MSoqeFa4f+4zbntZCDUy0zMBCs6bw4UoJbOtWwarn9xDgZiw6lanGmuKe0/YbkA==",
+        "resolved": "0.6.0",
+        "contentHash": "gyRyO8EFn3u0AmnJCBBVDzjSKwfJUkrMIFWHL7ox/tp5buezNjWb7K6pyM33wkRRbSvhNqKSQhjoYYkSwPsBMw==",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.5.2",
-          "Microsoft.EntityFrameworkCore.Sqlite": "8.0.11"
+          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.6.0",
+          "Microsoft.EntityFrameworkCore.Sqlite": "10.0.8"
         }
       },
       "Autofac": {
@@ -1662,7 +1662,7 @@
       "Reaparr.Data": {
         "type": "Project",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.5.2, )",
+          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.6.0, )",
           "Autofac": "[9.1.0, )",
           "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.Data.Sqlite": "[10.0.9, )",

--- a/tests/UnitTests/Domain.UnitTests/packages.lock.json
+++ b/tests/UnitTests/Domain.UnitTests/packages.lock.json
@@ -1210,37 +1210,37 @@
       },
       "Quartz": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "Ko3I49Yz1DqlxWi+fXqdG0FYJlHyGnra86m9RSlhPjIoXy7ip8FxyYJ70HcHc5s3xije0QvX81qG2dlxLEI7hQ==",
+        "resolved": "3.18.2",
+        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "2.1.1"
         }
       },
       "Quartz.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "SYPUS3eOwbYFv9mXwAqz6R0G5SHztRg0qG7GzQBsncSEW7y2vRvcMxnaYM5bGP1fF4SFBMdYAj25gGgQvD+tOA==",
+        "resolved": "3.18.2",
+        "contentHash": "+P0z/WUQZF/QrY5wB1wgvl9/VkiWqGR/K5bdtjW1qiFBraEoe/dqfNTxXQPnSZHnha1qmSBRoa5oA7kwHPsTqA==",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
           "Microsoft.Extensions.Options": "10.0.0",
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Quartz.Extensions.Hosting": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "6XgnbMBMsn5a7u2amkZVWKljVCQnO45SxDznpaRonXWolLNeX6Fx5t/73zigVshGLs3Q1A+NSv5z6oPTgv37sA==",
+        "resolved": "3.18.2",
+        "contentHash": "6uSMAm4FArjtVoxBjlkA+gHL1Eln2ngIOnRTrVrYxtSlM5PpLQd2aV+fc/OOwfwt+AyDm69HOAybEFqVvyyG2A==",
         "dependencies": {
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
-          "Quartz.Extensions.DependencyInjection": "3.17.0"
+          "Quartz.Extensions.DependencyInjection": "3.18.2"
         }
       },
       "Quartz.Serialization.SystemTextJson": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "QfqaugT/yokgUGhSrWHIpEGBUOhs0KJKZEd0WLIEoOj7m/eourC495pz1S/vq3I8LN81k6n8Pn6oky8qr3P2iw==",
+        "resolved": "3.18.2",
+        "contentHash": "FZAV4mUwnl4yNSa73ZuQNvBOZeyuPTUW4M8Mxa0XAFHUwgHGEYmqOVSgaztAET+a/fUGNBzj0eEPW2pZMQPYuA==",
         "dependencies": {
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Semver": {
@@ -1571,8 +1571,8 @@
           "Microsoft.AspNetCore.SpaServices.Extensions": "[10.0.9, )",
           "Microsoft.Extensions.Http.Polly": "[10.0.9, )",
           "Photino.NET": "[4.0.16, )",
-          "Quartz": "[3.17.0, )",
-          "Quartz.Extensions.Hosting": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
+          "Quartz.Extensions.Hosting": "[3.18.2, )",
           "Reaparr.Application": "[1.0.0, )",
           "Reaparr.BackgroundJobs": "[1.0.0, )",
           "Reaparr.Data": "[1.0.0, )",
@@ -1598,7 +1598,7 @@
           "FastEndpoints.Swagger": "[8.1.0, )",
           "Polly": "[8.6.5, )",
           "Polly.Core": "[8.6.6, )",
-          "Quartz.Serialization.SystemTextJson": "[3.17.0, )",
+          "Quartz.Serialization.SystemTextJson": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -1618,7 +1618,7 @@
       "Reaparr.Application.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },
@@ -1626,7 +1626,7 @@
         "type": "Project",
         "dependencies": {
           "Autofac.Extras.Quartz": "[11.0.0, )",
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -1638,7 +1638,7 @@
       "Reaparr.BackgroundJobs.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },

--- a/tests/UnitTests/Environment.UnitTests/packages.lock.json
+++ b/tests/UnitTests/Environment.UnitTests/packages.lock.json
@@ -29,19 +29,19 @@
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "6PBrhEH4S0t5T0DFZgmxPB7jXsEhkxaI6EY6Qt0r9NzOM8S0ukGcnROfPfgMkh7bpqZt/yhD4T7G2ObGBADhMA==",
+        "resolved": "0.6.0",
+        "contentHash": "hhhg6TeGEl5qczPD67xhJ9IYCpZ7PAd6CNiaA9vqK9a8y9tdXUp/Nkca19oTs55BxF8mmNSNUTjnO4T7lhKnvQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "8.0.11"
+          "Microsoft.EntityFrameworkCore": "10.0.8"
         }
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "ZzZScJNxyUuijtf0bl0rN6/MSoqeFa4f+4zbntZCDUy0zMBCs6bw4UoJbOtWwarn9xDgZiw6lanGmuKe0/YbkA==",
+        "resolved": "0.6.0",
+        "contentHash": "gyRyO8EFn3u0AmnJCBBVDzjSKwfJUkrMIFWHL7ox/tp5buezNjWb7K6pyM33wkRRbSvhNqKSQhjoYYkSwPsBMw==",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.5.2",
-          "Microsoft.EntityFrameworkCore.Sqlite": "8.0.11"
+          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.6.0",
+          "Microsoft.EntityFrameworkCore.Sqlite": "10.0.8"
         }
       },
       "Autofac": {
@@ -1662,7 +1662,7 @@
       "Reaparr.Data": {
         "type": "Project",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.5.2, )",
+          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.6.0, )",
           "Autofac": "[9.1.0, )",
           "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.Data.Sqlite": "[10.0.9, )",

--- a/tests/UnitTests/Environment.UnitTests/packages.lock.json
+++ b/tests/UnitTests/Environment.UnitTests/packages.lock.json
@@ -1210,37 +1210,37 @@
       },
       "Quartz": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "Ko3I49Yz1DqlxWi+fXqdG0FYJlHyGnra86m9RSlhPjIoXy7ip8FxyYJ70HcHc5s3xije0QvX81qG2dlxLEI7hQ==",
+        "resolved": "3.18.2",
+        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "2.1.1"
         }
       },
       "Quartz.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "SYPUS3eOwbYFv9mXwAqz6R0G5SHztRg0qG7GzQBsncSEW7y2vRvcMxnaYM5bGP1fF4SFBMdYAj25gGgQvD+tOA==",
+        "resolved": "3.18.2",
+        "contentHash": "+P0z/WUQZF/QrY5wB1wgvl9/VkiWqGR/K5bdtjW1qiFBraEoe/dqfNTxXQPnSZHnha1qmSBRoa5oA7kwHPsTqA==",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
           "Microsoft.Extensions.Options": "10.0.0",
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Quartz.Extensions.Hosting": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "6XgnbMBMsn5a7u2amkZVWKljVCQnO45SxDznpaRonXWolLNeX6Fx5t/73zigVshGLs3Q1A+NSv5z6oPTgv37sA==",
+        "resolved": "3.18.2",
+        "contentHash": "6uSMAm4FArjtVoxBjlkA+gHL1Eln2ngIOnRTrVrYxtSlM5PpLQd2aV+fc/OOwfwt+AyDm69HOAybEFqVvyyG2A==",
         "dependencies": {
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
-          "Quartz.Extensions.DependencyInjection": "3.17.0"
+          "Quartz.Extensions.DependencyInjection": "3.18.2"
         }
       },
       "Quartz.Serialization.SystemTextJson": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "QfqaugT/yokgUGhSrWHIpEGBUOhs0KJKZEd0WLIEoOj7m/eourC495pz1S/vq3I8LN81k6n8Pn6oky8qr3P2iw==",
+        "resolved": "3.18.2",
+        "contentHash": "FZAV4mUwnl4yNSa73ZuQNvBOZeyuPTUW4M8Mxa0XAFHUwgHGEYmqOVSgaztAET+a/fUGNBzj0eEPW2pZMQPYuA==",
         "dependencies": {
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Semver": {
@@ -1571,8 +1571,8 @@
           "Microsoft.AspNetCore.SpaServices.Extensions": "[10.0.9, )",
           "Microsoft.Extensions.Http.Polly": "[10.0.9, )",
           "Photino.NET": "[4.0.16, )",
-          "Quartz": "[3.17.0, )",
-          "Quartz.Extensions.Hosting": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
+          "Quartz.Extensions.Hosting": "[3.18.2, )",
           "Reaparr.Application": "[1.0.0, )",
           "Reaparr.BackgroundJobs": "[1.0.0, )",
           "Reaparr.Data": "[1.0.0, )",
@@ -1598,7 +1598,7 @@
           "FastEndpoints.Swagger": "[8.1.0, )",
           "Polly": "[8.6.5, )",
           "Polly.Core": "[8.6.6, )",
-          "Quartz.Serialization.SystemTextJson": "[3.17.0, )",
+          "Quartz.Serialization.SystemTextJson": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -1618,7 +1618,7 @@
       "Reaparr.Application.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },
@@ -1626,7 +1626,7 @@
         "type": "Project",
         "dependencies": {
           "Autofac.Extras.Quartz": "[11.0.0, )",
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -1638,7 +1638,7 @@
       "Reaparr.BackgroundJobs.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },

--- a/tests/UnitTests/External.UnitTests/packages.lock.json
+++ b/tests/UnitTests/External.UnitTests/packages.lock.json
@@ -35,19 +35,19 @@
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "6PBrhEH4S0t5T0DFZgmxPB7jXsEhkxaI6EY6Qt0r9NzOM8S0ukGcnROfPfgMkh7bpqZt/yhD4T7G2ObGBADhMA==",
+        "resolved": "0.6.0",
+        "contentHash": "hhhg6TeGEl5qczPD67xhJ9IYCpZ7PAd6CNiaA9vqK9a8y9tdXUp/Nkca19oTs55BxF8mmNSNUTjnO4T7lhKnvQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "8.0.11"
+          "Microsoft.EntityFrameworkCore": "10.0.8"
         }
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "ZzZScJNxyUuijtf0bl0rN6/MSoqeFa4f+4zbntZCDUy0zMBCs6bw4UoJbOtWwarn9xDgZiw6lanGmuKe0/YbkA==",
+        "resolved": "0.6.0",
+        "contentHash": "gyRyO8EFn3u0AmnJCBBVDzjSKwfJUkrMIFWHL7ox/tp5buezNjWb7K6pyM33wkRRbSvhNqKSQhjoYYkSwPsBMw==",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.5.2",
-          "Microsoft.EntityFrameworkCore.Sqlite": "8.0.11"
+          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.6.0",
+          "Microsoft.EntityFrameworkCore.Sqlite": "10.0.8"
         }
       },
       "Autofac": {
@@ -1663,7 +1663,7 @@
       "Reaparr.Data": {
         "type": "Project",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.5.2, )",
+          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.6.0, )",
           "Autofac": "[9.1.0, )",
           "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.Data.Sqlite": "[10.0.9, )",

--- a/tests/UnitTests/External.UnitTests/packages.lock.json
+++ b/tests/UnitTests/External.UnitTests/packages.lock.json
@@ -1216,37 +1216,37 @@
       },
       "Quartz": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "Ko3I49Yz1DqlxWi+fXqdG0FYJlHyGnra86m9RSlhPjIoXy7ip8FxyYJ70HcHc5s3xije0QvX81qG2dlxLEI7hQ==",
+        "resolved": "3.18.2",
+        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "2.1.1"
         }
       },
       "Quartz.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "SYPUS3eOwbYFv9mXwAqz6R0G5SHztRg0qG7GzQBsncSEW7y2vRvcMxnaYM5bGP1fF4SFBMdYAj25gGgQvD+tOA==",
+        "resolved": "3.18.2",
+        "contentHash": "+P0z/WUQZF/QrY5wB1wgvl9/VkiWqGR/K5bdtjW1qiFBraEoe/dqfNTxXQPnSZHnha1qmSBRoa5oA7kwHPsTqA==",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
           "Microsoft.Extensions.Options": "10.0.0",
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Quartz.Extensions.Hosting": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "6XgnbMBMsn5a7u2amkZVWKljVCQnO45SxDznpaRonXWolLNeX6Fx5t/73zigVshGLs3Q1A+NSv5z6oPTgv37sA==",
+        "resolved": "3.18.2",
+        "contentHash": "6uSMAm4FArjtVoxBjlkA+gHL1Eln2ngIOnRTrVrYxtSlM5PpLQd2aV+fc/OOwfwt+AyDm69HOAybEFqVvyyG2A==",
         "dependencies": {
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
-          "Quartz.Extensions.DependencyInjection": "3.17.0"
+          "Quartz.Extensions.DependencyInjection": "3.18.2"
         }
       },
       "Quartz.Serialization.SystemTextJson": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "QfqaugT/yokgUGhSrWHIpEGBUOhs0KJKZEd0WLIEoOj7m/eourC495pz1S/vq3I8LN81k6n8Pn6oky8qr3P2iw==",
+        "resolved": "3.18.2",
+        "contentHash": "FZAV4mUwnl4yNSa73ZuQNvBOZeyuPTUW4M8Mxa0XAFHUwgHGEYmqOVSgaztAET+a/fUGNBzj0eEPW2pZMQPYuA==",
         "dependencies": {
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Semver": {
@@ -1572,8 +1572,8 @@
           "Microsoft.AspNetCore.SpaServices.Extensions": "[10.0.9, )",
           "Microsoft.Extensions.Http.Polly": "[10.0.9, )",
           "Photino.NET": "[4.0.16, )",
-          "Quartz": "[3.17.0, )",
-          "Quartz.Extensions.Hosting": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
+          "Quartz.Extensions.Hosting": "[3.18.2, )",
           "Reaparr.Application": "[1.0.0, )",
           "Reaparr.BackgroundJobs": "[1.0.0, )",
           "Reaparr.Data": "[1.0.0, )",
@@ -1599,7 +1599,7 @@
           "FastEndpoints.Swagger": "[8.1.0, )",
           "Polly": "[8.6.5, )",
           "Polly.Core": "[8.6.6, )",
-          "Quartz.Serialization.SystemTextJson": "[3.17.0, )",
+          "Quartz.Serialization.SystemTextJson": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -1619,7 +1619,7 @@
       "Reaparr.Application.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },
@@ -1627,7 +1627,7 @@
         "type": "Project",
         "dependencies": {
           "Autofac.Extras.Quartz": "[11.0.0, )",
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -1639,7 +1639,7 @@
       "Reaparr.BackgroundJobs.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },

--- a/tests/UnitTests/FileSystem.UnitTests/packages.lock.json
+++ b/tests/UnitTests/FileSystem.UnitTests/packages.lock.json
@@ -29,19 +29,19 @@
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "6PBrhEH4S0t5T0DFZgmxPB7jXsEhkxaI6EY6Qt0r9NzOM8S0ukGcnROfPfgMkh7bpqZt/yhD4T7G2ObGBADhMA==",
+        "resolved": "0.6.0",
+        "contentHash": "hhhg6TeGEl5qczPD67xhJ9IYCpZ7PAd6CNiaA9vqK9a8y9tdXUp/Nkca19oTs55BxF8mmNSNUTjnO4T7lhKnvQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "8.0.11"
+          "Microsoft.EntityFrameworkCore": "10.0.8"
         }
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "ZzZScJNxyUuijtf0bl0rN6/MSoqeFa4f+4zbntZCDUy0zMBCs6bw4UoJbOtWwarn9xDgZiw6lanGmuKe0/YbkA==",
+        "resolved": "0.6.0",
+        "contentHash": "gyRyO8EFn3u0AmnJCBBVDzjSKwfJUkrMIFWHL7ox/tp5buezNjWb7K6pyM33wkRRbSvhNqKSQhjoYYkSwPsBMw==",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.5.2",
-          "Microsoft.EntityFrameworkCore.Sqlite": "8.0.11"
+          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.6.0",
+          "Microsoft.EntityFrameworkCore.Sqlite": "10.0.8"
         }
       },
       "Autofac": {
@@ -1662,7 +1662,7 @@
       "Reaparr.Data": {
         "type": "Project",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.5.2, )",
+          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.6.0, )",
           "Autofac": "[9.1.0, )",
           "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.Data.Sqlite": "[10.0.9, )",

--- a/tests/UnitTests/FileSystem.UnitTests/packages.lock.json
+++ b/tests/UnitTests/FileSystem.UnitTests/packages.lock.json
@@ -1210,37 +1210,37 @@
       },
       "Quartz": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "Ko3I49Yz1DqlxWi+fXqdG0FYJlHyGnra86m9RSlhPjIoXy7ip8FxyYJ70HcHc5s3xije0QvX81qG2dlxLEI7hQ==",
+        "resolved": "3.18.2",
+        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "2.1.1"
         }
       },
       "Quartz.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "SYPUS3eOwbYFv9mXwAqz6R0G5SHztRg0qG7GzQBsncSEW7y2vRvcMxnaYM5bGP1fF4SFBMdYAj25gGgQvD+tOA==",
+        "resolved": "3.18.2",
+        "contentHash": "+P0z/WUQZF/QrY5wB1wgvl9/VkiWqGR/K5bdtjW1qiFBraEoe/dqfNTxXQPnSZHnha1qmSBRoa5oA7kwHPsTqA==",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
           "Microsoft.Extensions.Options": "10.0.0",
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Quartz.Extensions.Hosting": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "6XgnbMBMsn5a7u2amkZVWKljVCQnO45SxDznpaRonXWolLNeX6Fx5t/73zigVshGLs3Q1A+NSv5z6oPTgv37sA==",
+        "resolved": "3.18.2",
+        "contentHash": "6uSMAm4FArjtVoxBjlkA+gHL1Eln2ngIOnRTrVrYxtSlM5PpLQd2aV+fc/OOwfwt+AyDm69HOAybEFqVvyyG2A==",
         "dependencies": {
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
-          "Quartz.Extensions.DependencyInjection": "3.17.0"
+          "Quartz.Extensions.DependencyInjection": "3.18.2"
         }
       },
       "Quartz.Serialization.SystemTextJson": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "QfqaugT/yokgUGhSrWHIpEGBUOhs0KJKZEd0WLIEoOj7m/eourC495pz1S/vq3I8LN81k6n8Pn6oky8qr3P2iw==",
+        "resolved": "3.18.2",
+        "contentHash": "FZAV4mUwnl4yNSa73ZuQNvBOZeyuPTUW4M8Mxa0XAFHUwgHGEYmqOVSgaztAET+a/fUGNBzj0eEPW2pZMQPYuA==",
         "dependencies": {
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Semver": {
@@ -1571,8 +1571,8 @@
           "Microsoft.AspNetCore.SpaServices.Extensions": "[10.0.9, )",
           "Microsoft.Extensions.Http.Polly": "[10.0.9, )",
           "Photino.NET": "[4.0.16, )",
-          "Quartz": "[3.17.0, )",
-          "Quartz.Extensions.Hosting": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
+          "Quartz.Extensions.Hosting": "[3.18.2, )",
           "Reaparr.Application": "[1.0.0, )",
           "Reaparr.BackgroundJobs": "[1.0.0, )",
           "Reaparr.Data": "[1.0.0, )",
@@ -1598,7 +1598,7 @@
           "FastEndpoints.Swagger": "[8.1.0, )",
           "Polly": "[8.6.5, )",
           "Polly.Core": "[8.6.6, )",
-          "Quartz.Serialization.SystemTextJson": "[3.17.0, )",
+          "Quartz.Serialization.SystemTextJson": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -1618,7 +1618,7 @@
       "Reaparr.Application.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },
@@ -1626,7 +1626,7 @@
         "type": "Project",
         "dependencies": {
           "Autofac.Extras.Quartz": "[11.0.0, )",
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -1638,7 +1638,7 @@
       "Reaparr.BackgroundJobs.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },

--- a/tests/UnitTests/FluentResultExtension.UnitTests/packages.lock.json
+++ b/tests/UnitTests/FluentResultExtension.UnitTests/packages.lock.json
@@ -29,19 +29,19 @@
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "6PBrhEH4S0t5T0DFZgmxPB7jXsEhkxaI6EY6Qt0r9NzOM8S0ukGcnROfPfgMkh7bpqZt/yhD4T7G2ObGBADhMA==",
+        "resolved": "0.6.0",
+        "contentHash": "hhhg6TeGEl5qczPD67xhJ9IYCpZ7PAd6CNiaA9vqK9a8y9tdXUp/Nkca19oTs55BxF8mmNSNUTjnO4T7lhKnvQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "8.0.11"
+          "Microsoft.EntityFrameworkCore": "10.0.8"
         }
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "ZzZScJNxyUuijtf0bl0rN6/MSoqeFa4f+4zbntZCDUy0zMBCs6bw4UoJbOtWwarn9xDgZiw6lanGmuKe0/YbkA==",
+        "resolved": "0.6.0",
+        "contentHash": "gyRyO8EFn3u0AmnJCBBVDzjSKwfJUkrMIFWHL7ox/tp5buezNjWb7K6pyM33wkRRbSvhNqKSQhjoYYkSwPsBMw==",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.5.2",
-          "Microsoft.EntityFrameworkCore.Sqlite": "8.0.11"
+          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.6.0",
+          "Microsoft.EntityFrameworkCore.Sqlite": "10.0.8"
         }
       },
       "Autofac": {
@@ -1662,7 +1662,7 @@
       "Reaparr.Data": {
         "type": "Project",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.5.2, )",
+          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.6.0, )",
           "Autofac": "[9.1.0, )",
           "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.Data.Sqlite": "[10.0.9, )",

--- a/tests/UnitTests/FluentResultExtension.UnitTests/packages.lock.json
+++ b/tests/UnitTests/FluentResultExtension.UnitTests/packages.lock.json
@@ -1210,37 +1210,37 @@
       },
       "Quartz": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "Ko3I49Yz1DqlxWi+fXqdG0FYJlHyGnra86m9RSlhPjIoXy7ip8FxyYJ70HcHc5s3xije0QvX81qG2dlxLEI7hQ==",
+        "resolved": "3.18.2",
+        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "2.1.1"
         }
       },
       "Quartz.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "SYPUS3eOwbYFv9mXwAqz6R0G5SHztRg0qG7GzQBsncSEW7y2vRvcMxnaYM5bGP1fF4SFBMdYAj25gGgQvD+tOA==",
+        "resolved": "3.18.2",
+        "contentHash": "+P0z/WUQZF/QrY5wB1wgvl9/VkiWqGR/K5bdtjW1qiFBraEoe/dqfNTxXQPnSZHnha1qmSBRoa5oA7kwHPsTqA==",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
           "Microsoft.Extensions.Options": "10.0.0",
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Quartz.Extensions.Hosting": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "6XgnbMBMsn5a7u2amkZVWKljVCQnO45SxDznpaRonXWolLNeX6Fx5t/73zigVshGLs3Q1A+NSv5z6oPTgv37sA==",
+        "resolved": "3.18.2",
+        "contentHash": "6uSMAm4FArjtVoxBjlkA+gHL1Eln2ngIOnRTrVrYxtSlM5PpLQd2aV+fc/OOwfwt+AyDm69HOAybEFqVvyyG2A==",
         "dependencies": {
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
-          "Quartz.Extensions.DependencyInjection": "3.17.0"
+          "Quartz.Extensions.DependencyInjection": "3.18.2"
         }
       },
       "Quartz.Serialization.SystemTextJson": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "QfqaugT/yokgUGhSrWHIpEGBUOhs0KJKZEd0WLIEoOj7m/eourC495pz1S/vq3I8LN81k6n8Pn6oky8qr3P2iw==",
+        "resolved": "3.18.2",
+        "contentHash": "FZAV4mUwnl4yNSa73ZuQNvBOZeyuPTUW4M8Mxa0XAFHUwgHGEYmqOVSgaztAET+a/fUGNBzj0eEPW2pZMQPYuA==",
         "dependencies": {
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Semver": {
@@ -1571,8 +1571,8 @@
           "Microsoft.AspNetCore.SpaServices.Extensions": "[10.0.9, )",
           "Microsoft.Extensions.Http.Polly": "[10.0.9, )",
           "Photino.NET": "[4.0.16, )",
-          "Quartz": "[3.17.0, )",
-          "Quartz.Extensions.Hosting": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
+          "Quartz.Extensions.Hosting": "[3.18.2, )",
           "Reaparr.Application": "[1.0.0, )",
           "Reaparr.BackgroundJobs": "[1.0.0, )",
           "Reaparr.Data": "[1.0.0, )",
@@ -1598,7 +1598,7 @@
           "FastEndpoints.Swagger": "[8.1.0, )",
           "Polly": "[8.6.5, )",
           "Polly.Core": "[8.6.6, )",
-          "Quartz.Serialization.SystemTextJson": "[3.17.0, )",
+          "Quartz.Serialization.SystemTextJson": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -1618,7 +1618,7 @@
       "Reaparr.Application.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },
@@ -1626,7 +1626,7 @@
         "type": "Project",
         "dependencies": {
           "Autofac.Extras.Quartz": "[11.0.0, )",
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -1638,7 +1638,7 @@
       "Reaparr.BackgroundJobs.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },

--- a/tests/UnitTests/Logging.UnitTests/packages.lock.json
+++ b/tests/UnitTests/Logging.UnitTests/packages.lock.json
@@ -29,19 +29,19 @@
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "6PBrhEH4S0t5T0DFZgmxPB7jXsEhkxaI6EY6Qt0r9NzOM8S0ukGcnROfPfgMkh7bpqZt/yhD4T7G2ObGBADhMA==",
+        "resolved": "0.6.0",
+        "contentHash": "hhhg6TeGEl5qczPD67xhJ9IYCpZ7PAd6CNiaA9vqK9a8y9tdXUp/Nkca19oTs55BxF8mmNSNUTjnO4T7lhKnvQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "8.0.11"
+          "Microsoft.EntityFrameworkCore": "10.0.8"
         }
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "ZzZScJNxyUuijtf0bl0rN6/MSoqeFa4f+4zbntZCDUy0zMBCs6bw4UoJbOtWwarn9xDgZiw6lanGmuKe0/YbkA==",
+        "resolved": "0.6.0",
+        "contentHash": "gyRyO8EFn3u0AmnJCBBVDzjSKwfJUkrMIFWHL7ox/tp5buezNjWb7K6pyM33wkRRbSvhNqKSQhjoYYkSwPsBMw==",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.5.2",
-          "Microsoft.EntityFrameworkCore.Sqlite": "8.0.11"
+          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.6.0",
+          "Microsoft.EntityFrameworkCore.Sqlite": "10.0.8"
         }
       },
       "Autofac": {
@@ -1662,7 +1662,7 @@
       "Reaparr.Data": {
         "type": "Project",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.5.2, )",
+          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.6.0, )",
           "Autofac": "[9.1.0, )",
           "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.Data.Sqlite": "[10.0.9, )",

--- a/tests/UnitTests/Logging.UnitTests/packages.lock.json
+++ b/tests/UnitTests/Logging.UnitTests/packages.lock.json
@@ -1210,37 +1210,37 @@
       },
       "Quartz": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "Ko3I49Yz1DqlxWi+fXqdG0FYJlHyGnra86m9RSlhPjIoXy7ip8FxyYJ70HcHc5s3xije0QvX81qG2dlxLEI7hQ==",
+        "resolved": "3.18.2",
+        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "2.1.1"
         }
       },
       "Quartz.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "SYPUS3eOwbYFv9mXwAqz6R0G5SHztRg0qG7GzQBsncSEW7y2vRvcMxnaYM5bGP1fF4SFBMdYAj25gGgQvD+tOA==",
+        "resolved": "3.18.2",
+        "contentHash": "+P0z/WUQZF/QrY5wB1wgvl9/VkiWqGR/K5bdtjW1qiFBraEoe/dqfNTxXQPnSZHnha1qmSBRoa5oA7kwHPsTqA==",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
           "Microsoft.Extensions.Options": "10.0.0",
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Quartz.Extensions.Hosting": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "6XgnbMBMsn5a7u2amkZVWKljVCQnO45SxDznpaRonXWolLNeX6Fx5t/73zigVshGLs3Q1A+NSv5z6oPTgv37sA==",
+        "resolved": "3.18.2",
+        "contentHash": "6uSMAm4FArjtVoxBjlkA+gHL1Eln2ngIOnRTrVrYxtSlM5PpLQd2aV+fc/OOwfwt+AyDm69HOAybEFqVvyyG2A==",
         "dependencies": {
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
-          "Quartz.Extensions.DependencyInjection": "3.17.0"
+          "Quartz.Extensions.DependencyInjection": "3.18.2"
         }
       },
       "Quartz.Serialization.SystemTextJson": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "QfqaugT/yokgUGhSrWHIpEGBUOhs0KJKZEd0WLIEoOj7m/eourC495pz1S/vq3I8LN81k6n8Pn6oky8qr3P2iw==",
+        "resolved": "3.18.2",
+        "contentHash": "FZAV4mUwnl4yNSa73ZuQNvBOZeyuPTUW4M8Mxa0XAFHUwgHGEYmqOVSgaztAET+a/fUGNBzj0eEPW2pZMQPYuA==",
         "dependencies": {
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Semver": {
@@ -1571,8 +1571,8 @@
           "Microsoft.AspNetCore.SpaServices.Extensions": "[10.0.9, )",
           "Microsoft.Extensions.Http.Polly": "[10.0.9, )",
           "Photino.NET": "[4.0.16, )",
-          "Quartz": "[3.17.0, )",
-          "Quartz.Extensions.Hosting": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
+          "Quartz.Extensions.Hosting": "[3.18.2, )",
           "Reaparr.Application": "[1.0.0, )",
           "Reaparr.BackgroundJobs": "[1.0.0, )",
           "Reaparr.Data": "[1.0.0, )",
@@ -1598,7 +1598,7 @@
           "FastEndpoints.Swagger": "[8.1.0, )",
           "Polly": "[8.6.5, )",
           "Polly.Core": "[8.6.6, )",
-          "Quartz.Serialization.SystemTextJson": "[3.17.0, )",
+          "Quartz.Serialization.SystemTextJson": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -1618,7 +1618,7 @@
       "Reaparr.Application.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },
@@ -1626,7 +1626,7 @@
         "type": "Project",
         "dependencies": {
           "Autofac.Extras.Quartz": "[11.0.0, )",
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -1638,7 +1638,7 @@
       "Reaparr.BackgroundJobs.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },

--- a/tests/UnitTests/PlexApi.UnitTests/PlexApiClient/PlexApiClient.UnitTests.cs
+++ b/tests/UnitTests/PlexApi.UnitTests/PlexApiClient/PlexApiClient.UnitTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.Json;
 using Moq.Contrib.HttpClient;
 using Moq.Protected;
+using Reaparr.Application.Contracts;
 using Reaparr.PlexApi.Contracts;
 
 namespace Reaparr.PlexApi.UnitTests;
@@ -66,7 +67,8 @@ public class PlexApiClientUnitTests : BaseUnitTest<Func<PlexApiClientOptions?, P
         });
 
         // Arrange
-        var client = Sut(new PlexApiClientOptions { ConnectionUrl = "http://localhost", RetryProgressAction = null });
+        var progressUpdates = new List<HttpRequestRetryProgress>();
+        var client = Sut(new PlexApiClientOptions { ConnectionUrl = "http://localhost", RetryProgressAction = progressUpdates.Add });
 
         // Act
         var responseMessage = await client.SendAsync(new HttpRequestMessage());
@@ -74,6 +76,10 @@ public class PlexApiClientUnitTests : BaseUnitTest<Func<PlexApiClientOptions?, P
         // Assert
         responseMessage.StatusCode.ShouldBe(HttpStatusCode.RequestTimeout);
         responseMessage.ReasonPhrase.ShouldBe("Request Timeout");
+        var progress = progressUpdates.ShouldHaveSingleItem();
+        progress.Completed.ShouldBeTrue();
+        progress.ConnectionSuccessful.ShouldBeFalse();
+        progress.StatusCode.ShouldBe((int)HttpStatusCode.RequestTimeout);
         HttpHandlerMock
             .Protected()
             .Verify("SendAsync", Times.Once(), ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
@@ -182,7 +188,8 @@ public class PlexApiClientUnitTests : BaseUnitTest<Func<PlexApiClientOptions?, P
         });
 
         // Arrange
-        var client = Sut(new PlexApiClientOptions { ConnectionUrl = "http://localhost", RetryProgressAction = null });
+        var progressUpdates = new List<HttpRequestRetryProgress>();
+        var client = Sut(new PlexApiClientOptions { ConnectionUrl = "http://localhost", RetryProgressAction = progressUpdates.Add });
 
         // Act
         var responseMessage = await client.SendAsync(new HttpRequestMessage());
@@ -190,6 +197,10 @@ public class PlexApiClientUnitTests : BaseUnitTest<Func<PlexApiClientOptions?, P
         // Assert
         responseMessage.StatusCode.ShouldBe(HttpStatusCode.BadGateway);
         responseMessage.ReasonPhrase.ShouldBe("Bad Gateway");
+        var progress = progressUpdates.ShouldHaveSingleItem();
+        progress.Completed.ShouldBeTrue();
+        progress.ConnectionSuccessful.ShouldBeFalse();
+        progress.StatusCode.ShouldBe((int)HttpStatusCode.BadGateway);
         HttpHandlerMock
             .Protected()
             .Verify("SendAsync", Times.Once(), ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());

--- a/tests/UnitTests/PlexApi.UnitTests/packages.lock.json
+++ b/tests/UnitTests/PlexApi.UnitTests/packages.lock.json
@@ -29,19 +29,19 @@
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "6PBrhEH4S0t5T0DFZgmxPB7jXsEhkxaI6EY6Qt0r9NzOM8S0ukGcnROfPfgMkh7bpqZt/yhD4T7G2ObGBADhMA==",
+        "resolved": "0.6.0",
+        "contentHash": "hhhg6TeGEl5qczPD67xhJ9IYCpZ7PAd6CNiaA9vqK9a8y9tdXUp/Nkca19oTs55BxF8mmNSNUTjnO4T7lhKnvQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "8.0.11"
+          "Microsoft.EntityFrameworkCore": "10.0.8"
         }
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "ZzZScJNxyUuijtf0bl0rN6/MSoqeFa4f+4zbntZCDUy0zMBCs6bw4UoJbOtWwarn9xDgZiw6lanGmuKe0/YbkA==",
+        "resolved": "0.6.0",
+        "contentHash": "gyRyO8EFn3u0AmnJCBBVDzjSKwfJUkrMIFWHL7ox/tp5buezNjWb7K6pyM33wkRRbSvhNqKSQhjoYYkSwPsBMw==",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.5.2",
-          "Microsoft.EntityFrameworkCore.Sqlite": "8.0.11"
+          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.6.0",
+          "Microsoft.EntityFrameworkCore.Sqlite": "10.0.8"
         }
       },
       "Autofac": {
@@ -1662,7 +1662,7 @@
       "Reaparr.Data": {
         "type": "Project",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.5.2, )",
+          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.6.0, )",
           "Autofac": "[9.1.0, )",
           "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.Data.Sqlite": "[10.0.9, )",

--- a/tests/UnitTests/PlexApi.UnitTests/packages.lock.json
+++ b/tests/UnitTests/PlexApi.UnitTests/packages.lock.json
@@ -1210,37 +1210,37 @@
       },
       "Quartz": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "Ko3I49Yz1DqlxWi+fXqdG0FYJlHyGnra86m9RSlhPjIoXy7ip8FxyYJ70HcHc5s3xije0QvX81qG2dlxLEI7hQ==",
+        "resolved": "3.18.2",
+        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "2.1.1"
         }
       },
       "Quartz.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "SYPUS3eOwbYFv9mXwAqz6R0G5SHztRg0qG7GzQBsncSEW7y2vRvcMxnaYM5bGP1fF4SFBMdYAj25gGgQvD+tOA==",
+        "resolved": "3.18.2",
+        "contentHash": "+P0z/WUQZF/QrY5wB1wgvl9/VkiWqGR/K5bdtjW1qiFBraEoe/dqfNTxXQPnSZHnha1qmSBRoa5oA7kwHPsTqA==",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
           "Microsoft.Extensions.Options": "10.0.0",
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Quartz.Extensions.Hosting": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "6XgnbMBMsn5a7u2amkZVWKljVCQnO45SxDznpaRonXWolLNeX6Fx5t/73zigVshGLs3Q1A+NSv5z6oPTgv37sA==",
+        "resolved": "3.18.2",
+        "contentHash": "6uSMAm4FArjtVoxBjlkA+gHL1Eln2ngIOnRTrVrYxtSlM5PpLQd2aV+fc/OOwfwt+AyDm69HOAybEFqVvyyG2A==",
         "dependencies": {
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
-          "Quartz.Extensions.DependencyInjection": "3.17.0"
+          "Quartz.Extensions.DependencyInjection": "3.18.2"
         }
       },
       "Quartz.Serialization.SystemTextJson": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "QfqaugT/yokgUGhSrWHIpEGBUOhs0KJKZEd0WLIEoOj7m/eourC495pz1S/vq3I8LN81k6n8Pn6oky8qr3P2iw==",
+        "resolved": "3.18.2",
+        "contentHash": "FZAV4mUwnl4yNSa73ZuQNvBOZeyuPTUW4M8Mxa0XAFHUwgHGEYmqOVSgaztAET+a/fUGNBzj0eEPW2pZMQPYuA==",
         "dependencies": {
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Semver": {
@@ -1571,8 +1571,8 @@
           "Microsoft.AspNetCore.SpaServices.Extensions": "[10.0.9, )",
           "Microsoft.Extensions.Http.Polly": "[10.0.9, )",
           "Photino.NET": "[4.0.16, )",
-          "Quartz": "[3.17.0, )",
-          "Quartz.Extensions.Hosting": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
+          "Quartz.Extensions.Hosting": "[3.18.2, )",
           "Reaparr.Application": "[1.0.0, )",
           "Reaparr.BackgroundJobs": "[1.0.0, )",
           "Reaparr.Data": "[1.0.0, )",
@@ -1598,7 +1598,7 @@
           "FastEndpoints.Swagger": "[8.1.0, )",
           "Polly": "[8.6.5, )",
           "Polly.Core": "[8.6.6, )",
-          "Quartz.Serialization.SystemTextJson": "[3.17.0, )",
+          "Quartz.Serialization.SystemTextJson": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -1618,7 +1618,7 @@
       "Reaparr.Application.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },
@@ -1626,7 +1626,7 @@
         "type": "Project",
         "dependencies": {
           "Autofac.Extras.Quartz": "[11.0.0, )",
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -1638,7 +1638,7 @@
       "Reaparr.BackgroundJobs.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },

--- a/tests/UnitTests/PublicApi.UnitTests/packages.lock.json
+++ b/tests/UnitTests/PublicApi.UnitTests/packages.lock.json
@@ -29,19 +29,19 @@
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "6PBrhEH4S0t5T0DFZgmxPB7jXsEhkxaI6EY6Qt0r9NzOM8S0ukGcnROfPfgMkh7bpqZt/yhD4T7G2ObGBADhMA==",
+        "resolved": "0.6.0",
+        "contentHash": "hhhg6TeGEl5qczPD67xhJ9IYCpZ7PAd6CNiaA9vqK9a8y9tdXUp/Nkca19oTs55BxF8mmNSNUTjnO4T7lhKnvQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "8.0.11"
+          "Microsoft.EntityFrameworkCore": "10.0.8"
         }
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "ZzZScJNxyUuijtf0bl0rN6/MSoqeFa4f+4zbntZCDUy0zMBCs6bw4UoJbOtWwarn9xDgZiw6lanGmuKe0/YbkA==",
+        "resolved": "0.6.0",
+        "contentHash": "gyRyO8EFn3u0AmnJCBBVDzjSKwfJUkrMIFWHL7ox/tp5buezNjWb7K6pyM33wkRRbSvhNqKSQhjoYYkSwPsBMw==",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.5.2",
-          "Microsoft.EntityFrameworkCore.Sqlite": "8.0.11"
+          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.6.0",
+          "Microsoft.EntityFrameworkCore.Sqlite": "10.0.8"
         }
       },
       "Autofac": {
@@ -1662,7 +1662,7 @@
       "Reaparr.Data": {
         "type": "Project",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.5.2, )",
+          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.6.0, )",
           "Autofac": "[9.1.0, )",
           "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.Data.Sqlite": "[10.0.9, )",

--- a/tests/UnitTests/PublicApi.UnitTests/packages.lock.json
+++ b/tests/UnitTests/PublicApi.UnitTests/packages.lock.json
@@ -1210,37 +1210,37 @@
       },
       "Quartz": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "Ko3I49Yz1DqlxWi+fXqdG0FYJlHyGnra86m9RSlhPjIoXy7ip8FxyYJ70HcHc5s3xije0QvX81qG2dlxLEI7hQ==",
+        "resolved": "3.18.2",
+        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "2.1.1"
         }
       },
       "Quartz.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "SYPUS3eOwbYFv9mXwAqz6R0G5SHztRg0qG7GzQBsncSEW7y2vRvcMxnaYM5bGP1fF4SFBMdYAj25gGgQvD+tOA==",
+        "resolved": "3.18.2",
+        "contentHash": "+P0z/WUQZF/QrY5wB1wgvl9/VkiWqGR/K5bdtjW1qiFBraEoe/dqfNTxXQPnSZHnha1qmSBRoa5oA7kwHPsTqA==",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
           "Microsoft.Extensions.Options": "10.0.0",
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Quartz.Extensions.Hosting": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "6XgnbMBMsn5a7u2amkZVWKljVCQnO45SxDznpaRonXWolLNeX6Fx5t/73zigVshGLs3Q1A+NSv5z6oPTgv37sA==",
+        "resolved": "3.18.2",
+        "contentHash": "6uSMAm4FArjtVoxBjlkA+gHL1Eln2ngIOnRTrVrYxtSlM5PpLQd2aV+fc/OOwfwt+AyDm69HOAybEFqVvyyG2A==",
         "dependencies": {
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
-          "Quartz.Extensions.DependencyInjection": "3.17.0"
+          "Quartz.Extensions.DependencyInjection": "3.18.2"
         }
       },
       "Quartz.Serialization.SystemTextJson": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "QfqaugT/yokgUGhSrWHIpEGBUOhs0KJKZEd0WLIEoOj7m/eourC495pz1S/vq3I8LN81k6n8Pn6oky8qr3P2iw==",
+        "resolved": "3.18.2",
+        "contentHash": "FZAV4mUwnl4yNSa73ZuQNvBOZeyuPTUW4M8Mxa0XAFHUwgHGEYmqOVSgaztAET+a/fUGNBzj0eEPW2pZMQPYuA==",
         "dependencies": {
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Semver": {
@@ -1571,8 +1571,8 @@
           "Microsoft.AspNetCore.SpaServices.Extensions": "[10.0.9, )",
           "Microsoft.Extensions.Http.Polly": "[10.0.9, )",
           "Photino.NET": "[4.0.16, )",
-          "Quartz": "[3.17.0, )",
-          "Quartz.Extensions.Hosting": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
+          "Quartz.Extensions.Hosting": "[3.18.2, )",
           "Reaparr.Application": "[1.0.0, )",
           "Reaparr.BackgroundJobs": "[1.0.0, )",
           "Reaparr.Data": "[1.0.0, )",
@@ -1598,7 +1598,7 @@
           "FastEndpoints.Swagger": "[8.1.0, )",
           "Polly": "[8.6.5, )",
           "Polly.Core": "[8.6.6, )",
-          "Quartz.Serialization.SystemTextJson": "[3.17.0, )",
+          "Quartz.Serialization.SystemTextJson": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -1618,7 +1618,7 @@
       "Reaparr.Application.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },
@@ -1626,7 +1626,7 @@
         "type": "Project",
         "dependencies": {
           "Autofac.Extras.Quartz": "[11.0.0, )",
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -1638,7 +1638,7 @@
       "Reaparr.BackgroundJobs.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },

--- a/tests/UnitTests/Settings.UnitTests/packages.lock.json
+++ b/tests/UnitTests/Settings.UnitTests/packages.lock.json
@@ -1204,37 +1204,37 @@
       },
       "Quartz": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "Ko3I49Yz1DqlxWi+fXqdG0FYJlHyGnra86m9RSlhPjIoXy7ip8FxyYJ70HcHc5s3xije0QvX81qG2dlxLEI7hQ==",
+        "resolved": "3.18.2",
+        "contentHash": "/KaRLj7jv84RSIR/UtAWnzYRmS7o/mA6CdEuoLwxhLa9Nfl7Q1keMA7Fe/r2BzRfDf+7YpN1QNEYSSU89DA3OA==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "2.1.1"
         }
       },
       "Quartz.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "SYPUS3eOwbYFv9mXwAqz6R0G5SHztRg0qG7GzQBsncSEW7y2vRvcMxnaYM5bGP1fF4SFBMdYAj25gGgQvD+tOA==",
+        "resolved": "3.18.2",
+        "contentHash": "+P0z/WUQZF/QrY5wB1wgvl9/VkiWqGR/K5bdtjW1qiFBraEoe/dqfNTxXQPnSZHnha1qmSBRoa5oA7kwHPsTqA==",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
           "Microsoft.Extensions.Options": "10.0.0",
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Quartz.Extensions.Hosting": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "6XgnbMBMsn5a7u2amkZVWKljVCQnO45SxDznpaRonXWolLNeX6Fx5t/73zigVshGLs3Q1A+NSv5z6oPTgv37sA==",
+        "resolved": "3.18.2",
+        "contentHash": "6uSMAm4FArjtVoxBjlkA+gHL1Eln2ngIOnRTrVrYxtSlM5PpLQd2aV+fc/OOwfwt+AyDm69HOAybEFqVvyyG2A==",
         "dependencies": {
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
-          "Quartz.Extensions.DependencyInjection": "3.17.0"
+          "Quartz.Extensions.DependencyInjection": "3.18.2"
         }
       },
       "Quartz.Serialization.SystemTextJson": {
         "type": "Transitive",
-        "resolved": "3.17.0",
-        "contentHash": "QfqaugT/yokgUGhSrWHIpEGBUOhs0KJKZEd0WLIEoOj7m/eourC495pz1S/vq3I8LN81k6n8Pn6oky8qr3P2iw==",
+        "resolved": "3.18.2",
+        "contentHash": "FZAV4mUwnl4yNSa73ZuQNvBOZeyuPTUW4M8Mxa0XAFHUwgHGEYmqOVSgaztAET+a/fUGNBzj0eEPW2pZMQPYuA==",
         "dependencies": {
-          "Quartz": "3.17.0"
+          "Quartz": "3.18.2"
         }
       },
       "Semver": {
@@ -1565,8 +1565,8 @@
           "Microsoft.AspNetCore.SpaServices.Extensions": "[10.0.9, )",
           "Microsoft.Extensions.Http.Polly": "[10.0.9, )",
           "Photino.NET": "[4.0.16, )",
-          "Quartz": "[3.17.0, )",
-          "Quartz.Extensions.Hosting": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
+          "Quartz.Extensions.Hosting": "[3.18.2, )",
           "Reaparr.Application": "[1.0.0, )",
           "Reaparr.BackgroundJobs": "[1.0.0, )",
           "Reaparr.Data": "[1.0.0, )",
@@ -1592,7 +1592,7 @@
           "FastEndpoints.Swagger": "[8.1.0, )",
           "Polly": "[8.6.5, )",
           "Polly.Core": "[8.6.6, )",
-          "Quartz.Serialization.SystemTextJson": "[3.17.0, )",
+          "Quartz.Serialization.SystemTextJson": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -1612,7 +1612,7 @@
       "Reaparr.Application.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },
@@ -1620,7 +1620,7 @@
         "type": "Project",
         "dependencies": {
           "Autofac.Extras.Quartz": "[11.0.0, )",
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Application.Contracts": "[1.0.0, )",
           "Reaparr.BackgroundJobs.Contracts": "[1.0.0, )",
           "Reaparr.Data.Contracts": "[1.0.0, )",
@@ -1632,7 +1632,7 @@
       "Reaparr.BackgroundJobs.Contracts": {
         "type": "Project",
         "dependencies": {
-          "Quartz": "[3.17.0, )",
+          "Quartz": "[3.18.2, )",
           "Reaparr.Domain": "[1.0.0, )"
         }
       },

--- a/tests/UnitTests/Settings.UnitTests/packages.lock.json
+++ b/tests/UnitTests/Settings.UnitTests/packages.lock.json
@@ -23,19 +23,19 @@
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "6PBrhEH4S0t5T0DFZgmxPB7jXsEhkxaI6EY6Qt0r9NzOM8S0ukGcnROfPfgMkh7bpqZt/yhD4T7G2ObGBADhMA==",
+        "resolved": "0.6.0",
+        "contentHash": "hhhg6TeGEl5qczPD67xhJ9IYCpZ7PAd6CNiaA9vqK9a8y9tdXUp/Nkca19oTs55BxF8mmNSNUTjnO4T7lhKnvQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "8.0.11"
+          "Microsoft.EntityFrameworkCore": "10.0.8"
         }
       },
       "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": {
         "type": "Transitive",
-        "resolved": "0.5.2",
-        "contentHash": "ZzZScJNxyUuijtf0bl0rN6/MSoqeFa4f+4zbntZCDUy0zMBCs6bw4UoJbOtWwarn9xDgZiw6lanGmuKe0/YbkA==",
+        "resolved": "0.6.0",
+        "contentHash": "gyRyO8EFn3u0AmnJCBBVDzjSKwfJUkrMIFWHL7ox/tp5buezNjWb7K6pyM33wkRRbSvhNqKSQhjoYYkSwPsBMw==",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.5.2",
-          "Microsoft.EntityFrameworkCore.Sqlite": "8.0.11"
+          "AppAny.Quartz.EntityFrameworkCore.Migrations": "0.6.0",
+          "Microsoft.EntityFrameworkCore.Sqlite": "10.0.8"
         }
       },
       "Autofac": {
@@ -1656,7 +1656,7 @@
       "Reaparr.Data": {
         "type": "Project",
         "dependencies": {
-          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.5.2, )",
+          "AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite": "[0.6.0, )",
           "Autofac": "[9.1.0, )",
           "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.Data.Sqlite": "[10.0.9, )",


### PR DESCRIPTION
…NET connections

Quartz's AdoJobStore opens raw ADO.NET SqliteConnection objects that
bypass the EF Core SqliteConnectionEnhancer interceptor pipeline. Without
busy_timeout, concurrent writes fail instantly with SQLITE_BUSY
('database is locked') during MisfireHandler.Manage().

Add QuartzSqliteConnectionProvider — a custom IDbProvider that hooks
StateChange to call SqliteConnectionEnhancer.ApplyRuntimePragmas() on
every connection Open(), applying the same PRAGMAs (WAL, busy_timeout,
synchronous, cache_size, etc.) as EF Core connections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable timeout support for Plex server status requests and connection-check operations.
* **Bug Fixes**
  * Improved Quartz SQLite stability by applying per-connection settings (including busy timeout).
  * Continued inspecting remaining Plex servers even if one server’s connection check fails.
* **Performance**
  * Streamlined actor/genre/country metadata synchronization using batched insert-or-ignore upserts.
* **Refactor**
  * Plex server inspection now uses a fresh database context per server for parallel runs.
* **Tests**
  * Expanded unit tests for timeouts, retry/progress completion signaling, parallel inspection, and partial failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->